### PR TITLE
Dual-strategy foundation: strategy_id lanes across bot state/journal/dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ market stream
 
 key persisted outputs:
 - `data/candles/ETH-USD-15m.jsonl`
-- `data/journal/YYYY-MM-DD.jsonl`
-- `data/state/current.json`
-- `data/state/snapshot.json`
+- conservative lane (default/backward-compatible):
+  - `data/journal/YYYY-MM-DD.jsonl`
+  - `data/state/current.json`
+  - `data/state/snapshot.json`
+- non-default strategy lanes:
+  - `data/strategies/<strategy_id>/journal/YYYY-MM-DD.jsonl`
+  - `data/strategies/<strategy_id>/state/current.json`
+  - `data/strategies/<strategy_id>/state/snapshot.json`
 
 ---
 
@@ -73,7 +78,8 @@ python -m bot.feed_listener --pair "ETH/USD" --tf-min 15
 ### 3) run one cycle manually
 
 ```bash
-python -m bot.run_cycle --pair "ETH/USD" --tf-min 15
+python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id conservative
+python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id aggressive
 ```
 
 ---

--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,11 @@
   "pair": "ETH/USD",
   "tf_min": 15,
 
+  "strategy": {
+    "default_id": "conservative",
+    "allowed_ids": ["conservative", "aggressive"]
+  },
+
   "risk": {
     "risk_pct": 0.03,
     "min_risk_usd": 10.0,

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -14,6 +14,12 @@ const JOURNAL_DIR = process.env.JOURNAL_DIR ||
 const CANDLES_PATH = process.env.CANDLES_PATH ||
   '/etc/dokploy/compose/avantis-paper-bot-nsnxrq/code/data/candles/ETH-USD-15m.jsonl';
 
+const STRATEGY_DEFAULT_ID = process.env.STRATEGY_DEFAULT_ID || 'conservative';
+const STRATEGY_IDS = (process.env.STRATEGY_IDS || STRATEGY_DEFAULT_ID)
+  .split(',')
+  .map((x) => x.trim())
+  .filter(Boolean);
+
 const STALE_MINUTES = parseInt(process.env.STALE_MINUTES || '20', 10);
 
 const STRATEGY_DEFAULTS = {
@@ -28,6 +34,21 @@ const STRATEGY_DEFAULTS = {
     'If insufficient candles, signal stays flat'
   ]
 };
+
+function normalizeStrategyId(raw) {
+  const v = String(raw || STRATEGY_DEFAULT_ID).trim();
+  return STRATEGY_IDS.includes(v) ? v : STRATEGY_DEFAULT_ID;
+}
+
+function strategySnapshotPath(strategyId) {
+  if (strategyId === STRATEGY_DEFAULT_ID) return SNAPSHOT_PATH;
+  return SNAPSHOT_PATH.replace(/\/state\/snapshot\.json$/, `/strategies/${strategyId}/state/snapshot.json`);
+}
+
+function strategyJournalDir(strategyId) {
+  if (strategyId === STRATEGY_DEFAULT_ID) return JOURNAL_DIR;
+  return JOURNAL_DIR.replace(/\/journal$/, `/strategies/${strategyId}/journal`);
+}
 
 app.use(express.static(path.join(process.cwd(), 'public')));
 
@@ -56,8 +77,8 @@ async function readJsonSafe(p) {
   return JSON.parse(raw);
 }
 
-async function listJournalFile(dateStr) {
-  const p = path.join(JOURNAL_DIR, `${dateStr}.jsonl`);
+async function listJournalFile(dateStr, strategyId = STRATEGY_DEFAULT_ID) {
+  const p = path.join(strategyJournalDir(strategyId), `${dateStr}.jsonl`);
   return p;
 }
 
@@ -230,18 +251,22 @@ app.get('/api/meta', async (_req, res) => {
     port: PORT,
     snapshotPath: SNAPSHOT_PATH,
     journalDir: JOURNAL_DIR,
+    strategyDefaultId: STRATEGY_DEFAULT_ID,
+    strategyIds: STRATEGY_IDS,
     staleMinutes: STALE_MINUTES
   });
 });
 
-app.get('/api/status', async (_req, res) => {
-  const snapshotStat = await statSafe(SNAPSHOT_PATH);
+app.get('/api/status', async (req, res) => {
+  const strategyId = normalizeStrategyId(req.query.strategy_id);
+  const strategySnapshot = strategySnapshotPath(strategyId);
+  const snapshotStat = await statSafe(strategySnapshot);
 
   let snapshot = null;
   let snapshotError = null;
   if (snapshotStat.ok) {
     try {
-      snapshot = await readJsonSafe(SNAPSHOT_PATH);
+      snapshot = await readJsonSafe(strategySnapshot);
     } catch (e) {
       snapshotError = e?.message || String(e);
     }
@@ -254,8 +279,9 @@ app.get('/api/status', async (_req, res) => {
 
   res.json({
     ok: true,
+    strategy_id: strategyId,
     snapshot: {
-      path: SNAPSHOT_PATH,
+      path: strategySnapshot,
       stat: snapshotStat,
       minsStale: snapshotMinsStale,
       isStale: snapshotIsStale,
@@ -265,11 +291,45 @@ app.get('/api/status', async (_req, res) => {
   });
 });
 
+app.get('/api/statuses', async (_req, res) => {
+  const rows = [];
+  for (const strategyId of STRATEGY_IDS) {
+    const strategySnapshot = strategySnapshotPath(strategyId);
+    const snapshotStat = await statSafe(strategySnapshot);
+
+    let snapshot = null;
+    let snapshotError = null;
+    if (snapshotStat.ok) {
+      try {
+        snapshot = await readJsonSafe(strategySnapshot);
+      } catch (e) {
+        snapshotError = e?.message || String(e);
+      }
+    }
+
+    const snapshotMinsStale = snapshotStat.ok ? minutesSince(snapshotStat.mtimeMs) : null;
+    rows.push({
+      strategy_id: strategyId,
+      snapshot: {
+        path: strategySnapshot,
+        stat: snapshotStat,
+        minsStale: snapshotMinsStale,
+        isStale: snapshotStat.ok ? snapshotMinsStale > STALE_MINUTES : true,
+        parseError: snapshotError
+      },
+      status: snapshot ? extractStatus(snapshot) : null
+    });
+  }
+
+  res.json({ ok: true, strategies: rows });
+});
+
 app.get('/api/timeline', async (req, res) => {
+  const strategyId = normalizeStrategyId(req.query.strategy_id);
   const date = (req.query.date && String(req.query.date)) || utcDateString();
   const max = Math.min(500, Math.max(1, parseInt(req.query.max || '200', 10)));
 
-  const journalPath = await listJournalFile(date);
+  const journalPath = await listJournalFile(date, strategyId);
   const journalStat = await statSafe(journalPath);
 
   let events = [];
@@ -298,6 +358,7 @@ app.get('/api/timeline', async (req, res) => {
 
   res.json({
     ok: true,
+    strategy_id: strategyId,
     date,
     journal: {
       path: journalPath,
@@ -314,8 +375,9 @@ app.get('/api/timeline', async (req, res) => {
 const WATCHDOG_LOG_PATH = process.env.WATCHDOG_LOG_PATH || '/tmp/apb_feed_watchdog.log';
 
 app.get('/api/chart', async (req, res) => {
+  const strategyId = normalizeStrategyId(req.query.strategy_id);
   const date = (req.query.date && String(req.query.date)) || utcDateString();
-  const journalPath = await listJournalFile(date);
+  const journalPath = await listJournalFile(date, strategyId);
 
   let candles = [];
   try {
@@ -409,6 +471,7 @@ app.get('/api/chart', async (req, res) => {
 
   res.json({
     ok: true,
+    strategy_id: strategyId,
     date,
     candles,
     markers,
@@ -419,8 +482,9 @@ app.get('/api/chart', async (req, res) => {
 });
 
 app.get('/api/report/daily', async (req, res) => {
+  const strategyId = normalizeStrategyId(req.query.strategy_id);
   const date = (req.query.date && String(req.query.date)) || utcDateString();
-  const journalPath = await listJournalFile(date);
+  const journalPath = await listJournalFile(date, strategyId);
   const journalStat = await statSafe(journalPath);
   const candlesStat = await statSafe(CANDLES_PATH);
 
@@ -458,6 +522,7 @@ app.get('/api/report/daily', async (req, res) => {
 
   res.json({
     ok: true,
+    strategy_id: strategyId,
     date,
     summary: {
       cycleCount: cycles.length,

--- a/src/bot/config.py
+++ b/src/bot/config.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from typing import Any
 
 
+DEFAULT_STRATEGY_ID = "conservative"
+
+
 @dataclass
 class RiskConfig:
     # Baseline risk target (still clamped by min/max below)
@@ -33,10 +36,17 @@ class RiskConfig:
 
 
 @dataclass
+class StrategyConfig:
+    default_id: str = DEFAULT_STRATEGY_ID
+    allowed_ids: list[str] = field(default_factory=lambda: [DEFAULT_STRATEGY_ID])
+
+
+@dataclass
 class BotConfig:
     pair: str = "ETH/USD"
     tf_min: int = 15
     risk: RiskConfig = field(default_factory=RiskConfig)
+    strategy: StrategyConfig = field(default_factory=StrategyConfig)
 
 
 def load_config() -> BotConfig:
@@ -69,6 +79,20 @@ def load_config() -> BotConfig:
         daily_kill_switch_pct=float(r.get("daily_kill_switch_pct", cfg.risk.daily_kill_switch_pct)),
         min_collateral_usd=float(r.get("min_collateral_usd", cfg.risk.min_collateral_usd)),
     )
+
+    s = data.get("strategy", {}) or {}
+    allowed = s.get("allowed_ids", [cfg.strategy.default_id])
+    if not isinstance(allowed, list) or not allowed:
+        allowed = [cfg.strategy.default_id]
+    allowed_ids = [str(x).strip() for x in allowed if str(x).strip()]
+    if DEFAULT_STRATEGY_ID not in allowed_ids:
+        allowed_ids.insert(0, DEFAULT_STRATEGY_ID)
+
+    default_id = str(s.get("default_id", cfg.strategy.default_id)).strip() or DEFAULT_STRATEGY_ID
+    if default_id not in allowed_ids:
+        allowed_ids.insert(0, default_id)
+
+    cfg.strategy = StrategyConfig(default_id=default_id, allowed_ids=allowed_ids)
 
     return cfg
 

--- a/src/bot/run_cycle.py
+++ b/src/bot/run_cycle.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from .config import as_dict, load_config
+from .config import DEFAULT_STRATEGY_ID, as_dict, load_config
 from .models import PaperState, Position
 from .paper_engine import execute_paper
 from .risk import compute_risk_budget, plan_from_signal
@@ -50,12 +50,19 @@ def main() -> None:
     ap.add_argument("--pair", default=cfg.pair)
     ap.add_argument("--tf-min", type=int, default=cfg.tf_min)
     ap.add_argument("--candle-limit", type=int, default=200)
+    ap.add_argument("--strategy-id", default=cfg.strategy.default_id)
     args = ap.parse_args()
+
+    strategy_id = (args.strategy_id or DEFAULT_STRATEGY_ID).strip()
+    if strategy_id not in cfg.strategy.allowed_ids:
+        raise SystemExit(
+            f"strategy_id '{strategy_id}' not allowed; allowed_ids={cfg.strategy.allowed_ids}"
+        )
 
     cpath = candles_path(args.pair, args.tf_min)
     candles = _load_recent_candles(cpath, limit=args.candle_limit)
 
-    raw_state = read_json(state_path(), default={"equity": 100.0, "position": None, "daily_pnl": 0.0})
+    raw_state = read_json(state_path(strategy_id), default={"equity": 100.0, "position": None, "daily_pnl": 0.0})
 
     # normalize to PaperState
     pos_raw = raw_state.get("position")
@@ -127,11 +134,12 @@ def main() -> None:
         note=f"cycle: candles={len(candles)} last_price={last_price:.2f} action={action_note}",
     )
 
-    jpath = journal_path(_today())
+    jpath = journal_path(_today(), strategy_id=strategy_id)
     jsonl_append(
         jpath,
         {
             "type": "cycle",
+            "strategy_id": strategy_id,
             "ts": res.ts,
             "pair": res.pair,
             "tf_min": res.tf_min,
@@ -154,6 +162,7 @@ def main() -> None:
     # Snapshot for dashboard
     snapshot = {
         "ts": now_ts,
+        "strategy_id": strategy_id,
         "pair": args.pair,
         "tf_min": args.tf_min,
         "equity": paper.equity,
@@ -168,17 +177,18 @@ def main() -> None:
     }
 
     write_json(
-        state_path(),
+        state_path(strategy_id),
         {
+            "strategy_id": strategy_id,
             "equity": paper.equity,
             "daily_pnl": paper.daily_pnl,
             "position": paper.position.__dict__ if paper.position else None,
             "last_price": paper.last_price,
         },
     )
-    write_json(snapshot_path(), snapshot)
+    write_json(snapshot_path(strategy_id), snapshot)
 
-    print(f"[cycle] wrote journal={jpath} snapshot={snapshot_path()}")
+    print(f"[cycle] strategy={strategy_id} wrote journal={jpath} snapshot={snapshot_path(strategy_id)}")
 
 
 if __name__ == "__main__":

--- a/src/bot/storage.py
+++ b/src/bot/storage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .config import DEFAULT_STRATEGY_ID
 from .utils import data_dir
 
 
@@ -10,13 +11,19 @@ def candles_path(pair: str, tf_min: int) -> Path:
     return data_dir() / "candles" / f"{sym}-{tf_min}m.jsonl"
 
 
-def journal_path(date_yyyy_mm_dd: str) -> Path:
-    return data_dir() / "journal" / f"{date_yyyy_mm_dd}.jsonl"
+def _strategy_root(strategy_id: str = DEFAULT_STRATEGY_ID) -> Path:
+    if strategy_id == DEFAULT_STRATEGY_ID:
+        return data_dir()
+    return data_dir() / "strategies" / strategy_id
 
 
-def state_path() -> Path:
-    return data_dir() / "state" / "current.json"
+def journal_path(date_yyyy_mm_dd: str, strategy_id: str = DEFAULT_STRATEGY_ID) -> Path:
+    return _strategy_root(strategy_id) / "journal" / f"{date_yyyy_mm_dd}.jsonl"
 
 
-def snapshot_path() -> Path:
-    return data_dir() / "state" / "snapshot.json"
+def state_path(strategy_id: str = DEFAULT_STRATEGY_ID) -> Path:
+    return _strategy_root(strategy_id) / "state" / "current.json"
+
+
+def snapshot_path(strategy_id: str = DEFAULT_STRATEGY_ID) -> Path:
+    return _strategy_root(strategy_id) / "state" / "snapshot.json"

--- a/src/bot/storage.py
+++ b/src/bot/storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from .config import DEFAULT_STRATEGY_ID
@@ -11,10 +12,23 @@ def candles_path(pair: str, tf_min: int) -> Path:
     return data_dir() / "candles" / f"{sym}-{tf_min}m.jsonl"
 
 
+_STRATEGY_ID_RE = re.compile(r"^[a-z0-9_-]+$")
+
+
+def _sanitize_strategy_id(strategy_id: str) -> str:
+    sid = (strategy_id or DEFAULT_STRATEGY_ID).strip()
+    if sid == DEFAULT_STRATEGY_ID:
+        return sid
+    if not _STRATEGY_ID_RE.match(sid):
+        raise ValueError(f"invalid strategy_id '{strategy_id}'")
+    return sid
+
+
 def _strategy_root(strategy_id: str = DEFAULT_STRATEGY_ID) -> Path:
-    if strategy_id == DEFAULT_STRATEGY_ID:
+    sid = _sanitize_strategy_id(strategy_id)
+    if sid == DEFAULT_STRATEGY_ID:
         return data_dir()
-    return data_dir() / "strategies" / strategy_id
+    return data_dir() / "strategies" / sid
 
 
 def journal_path(date_yyyy_mm_dd: str, strategy_id: str = DEFAULT_STRATEGY_ID) -> Path:


### PR DESCRIPTION
## summary
Implements the #7 foundation by introducing `strategy_id` lanes across runtime state, journal persistence, and dashboard APIs while preserving conservative backward compatibility.

## what changed
- config model now supports strategy config:
  - `strategy.default_id`
  - `strategy.allowed_ids`
- cycle runner accepts `--strategy-id` and validates against allowed ids
- storage routing now isolates non-default strategies under:
  - `data/strategies/<strategy_id>/state/*`
  - `data/strategies/<strategy_id>/journal/*`
- journal/state/snapshot records now include `strategy_id`
- dashboard API now supports strategy-aware reads via `strategy_id` query param:
  - `/api/status`
  - `/api/timeline`
  - `/api/chart`
  - `/api/report/daily`
- added `/api/statuses` to return all configured strategy snapshots in one payload
- updated config example + README run/persistence docs for dual-lane structure

## backward compatibility
- conservative remains default lane and uses existing legacy paths:
  - `data/state/*`
  - `data/journal/*`
- existing deployments continue working without config change.

## validation
- `python3 -m compileall src/bot`
- `node --check dashboard/server.js`

Closes #7
