### PR TITLE
Aggressive mode v1: profile-driven regime bias and confidence gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ risk controls are explicit and should be treated as first-class change surfaces:
 - deployed capital caps
 - kill-switch thresholds
 - sizing bounds
+- confidence thresholds (`min_confidence_to_trade`)
+
+strategy behavior can be profile-driven (`strategy.profiles`), so aggressive mode can use
+higher deployment + lower confidence gates while conservative remains unchanged.
 
 any change to these should go through reviewed PRs only.
 

--- a/config.example.json
+++ b/config.example.json
@@ -4,7 +4,21 @@
 
   "strategy": {
     "default_id": "conservative",
-    "allowed_ids": ["conservative", "aggressive"]
+    "allowed_ids": ["conservative", "aggressive"],
+    "profiles": {
+      "conservative": {},
+      "aggressive": {
+        "risk_pct": 0.05,
+        "max_deployed_pct": 0.90,
+        "max_leverage": 2.0,
+        "min_confidence_to_trade": 0.25,
+        "trend_weight_in_regime": 1.8,
+        "adx_threshold": 16.0,
+        "tie_break_to_trend": true,
+        "tie_break_min_confidence": 0.18,
+        "regime_confidence_floor": 0.28
+      }
+    }
   },
 
   "risk": {
@@ -16,7 +30,8 @@
     "max_deployed_pct": 0.50,
     "daily_kill_switch_pct": -0.08,
 
-    "min_collateral_usd": 20.0
+    "min_collateral_usd": 20.0,
+    "min_confidence_to_trade": 0.60
   },
 
   "paper": {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1,6 +1,12 @@
 import express from 'express';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import {
+  normalizeStrategyId,
+  parseStrategyIds,
+  strategyJournalDir,
+  strategySnapshotPath,
+} from './strategy.mjs';
 
 const app = express();
 
@@ -15,10 +21,7 @@ const CANDLES_PATH = process.env.CANDLES_PATH ||
   '/etc/dokploy/compose/avantis-paper-bot-nsnxrq/code/data/candles/ETH-USD-15m.jsonl';
 
 const STRATEGY_DEFAULT_ID = process.env.STRATEGY_DEFAULT_ID || 'conservative';
-const STRATEGY_IDS = (process.env.STRATEGY_IDS || STRATEGY_DEFAULT_ID)
-  .split(',')
-  .map((x) => x.trim())
-  .filter(Boolean);
+const STRATEGY_IDS = parseStrategyIds(process.env.STRATEGY_IDS, STRATEGY_DEFAULT_ID);
 
 const STALE_MINUTES = parseInt(process.env.STALE_MINUTES || '20', 10);
 
@@ -35,20 +38,6 @@ const STRATEGY_DEFAULTS = {
   ]
 };
 
-function normalizeStrategyId(raw) {
-  const v = String(raw || STRATEGY_DEFAULT_ID).trim();
-  return STRATEGY_IDS.includes(v) ? v : STRATEGY_DEFAULT_ID;
-}
-
-function strategySnapshotPath(strategyId) {
-  if (strategyId === STRATEGY_DEFAULT_ID) return SNAPSHOT_PATH;
-  return SNAPSHOT_PATH.replace(/\/state\/snapshot\.json$/, `/strategies/${strategyId}/state/snapshot.json`);
-}
-
-function strategyJournalDir(strategyId) {
-  if (strategyId === STRATEGY_DEFAULT_ID) return JOURNAL_DIR;
-  return JOURNAL_DIR.replace(/\/journal$/, `/strategies/${strategyId}/journal`);
-}
 
 app.use(express.static(path.join(process.cwd(), 'public')));
 
@@ -78,7 +67,7 @@ async function readJsonSafe(p) {
 }
 
 async function listJournalFile(dateStr, strategyId = STRATEGY_DEFAULT_ID) {
-  const p = path.join(strategyJournalDir(strategyId), `${dateStr}.jsonl`);
+  const p = path.join(strategyJournalDir(JOURNAL_DIR, strategyId, STRATEGY_DEFAULT_ID), `${dateStr}.jsonl`);
   return p;
 }
 
@@ -258,8 +247,8 @@ app.get('/api/meta', async (_req, res) => {
 });
 
 app.get('/api/status', async (req, res) => {
-  const strategyId = normalizeStrategyId(req.query.strategy_id);
-  const strategySnapshot = strategySnapshotPath(strategyId);
+  const strategyId = normalizeStrategyId(req.query.strategy_id, STRATEGY_IDS, STRATEGY_DEFAULT_ID);
+  const strategySnapshot = strategySnapshotPath(SNAPSHOT_PATH, strategyId, STRATEGY_DEFAULT_ID);
   const snapshotStat = await statSafe(strategySnapshot);
 
   let snapshot = null;
@@ -294,7 +283,7 @@ app.get('/api/status', async (req, res) => {
 app.get('/api/statuses', async (_req, res) => {
   const rows = [];
   for (const strategyId of STRATEGY_IDS) {
-    const strategySnapshot = strategySnapshotPath(strategyId);
+    const strategySnapshot = strategySnapshotPath(SNAPSHOT_PATH, strategyId, STRATEGY_DEFAULT_ID);
     const snapshotStat = await statSafe(strategySnapshot);
 
     let snapshot = null;
@@ -325,7 +314,7 @@ app.get('/api/statuses', async (_req, res) => {
 });
 
 app.get('/api/timeline', async (req, res) => {
-  const strategyId = normalizeStrategyId(req.query.strategy_id);
+  const strategyId = normalizeStrategyId(req.query.strategy_id, STRATEGY_IDS, STRATEGY_DEFAULT_ID);
   const date = (req.query.date && String(req.query.date)) || utcDateString();
   const max = Math.min(500, Math.max(1, parseInt(req.query.max || '200', 10)));
 
@@ -375,7 +364,7 @@ app.get('/api/timeline', async (req, res) => {
 const WATCHDOG_LOG_PATH = process.env.WATCHDOG_LOG_PATH || '/tmp/apb_feed_watchdog.log';
 
 app.get('/api/chart', async (req, res) => {
-  const strategyId = normalizeStrategyId(req.query.strategy_id);
+  const strategyId = normalizeStrategyId(req.query.strategy_id, STRATEGY_IDS, STRATEGY_DEFAULT_ID);
   const date = (req.query.date && String(req.query.date)) || utcDateString();
   const journalPath = await listJournalFile(date, strategyId);
 
@@ -482,7 +471,7 @@ app.get('/api/chart', async (req, res) => {
 });
 
 app.get('/api/report/daily', async (req, res) => {
-  const strategyId = normalizeStrategyId(req.query.strategy_id);
+  const strategyId = normalizeStrategyId(req.query.strategy_id, STRATEGY_IDS, STRATEGY_DEFAULT_ID);
   const date = (req.query.date && String(req.query.date)) || utcDateString();
   const journalPath = await listJournalFile(date, strategyId);
   const journalStat = await statSafe(journalPath);

--- a/dashboard/strategy.mjs
+++ b/dashboard/strategy.mjs
@@ -1,0 +1,22 @@
+export function parseStrategyIds(raw, fallback = 'conservative') {
+  const vals = String(raw || fallback)
+    .split(',')
+    .map((x) => x.trim())
+    .filter(Boolean);
+  return vals.length ? vals : [fallback];
+}
+
+export function normalizeStrategyId(raw, strategyIds, defaultId = 'conservative') {
+  const v = String(raw || defaultId).trim();
+  return strategyIds.includes(v) ? v : defaultId;
+}
+
+export function strategySnapshotPath(baseSnapshotPath, strategyId, defaultId = 'conservative') {
+  if (strategyId === defaultId) return baseSnapshotPath;
+  return baseSnapshotPath.replace(/\/state\/snapshot\.json$/, `/strategies/${strategyId}/state/snapshot.json`);
+}
+
+export function strategyJournalDir(baseJournalDir, strategyId, defaultId = 'conservative') {
+  if (strategyId === defaultId) return baseJournalDir;
+  return baseJournalDir.replace(/\/journal$/, `/strategies/${strategyId}/journal`);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ apb-cycle = "bot.run_cycle:main"
 [project.optional-dependencies]
 dev = [
   "ruff>=0.6.0",
+  "pytest>=8.0.0",
 ]
 
 [tool.setuptools]

--- a/src/bot/config.py
+++ b/src/bot/config.py
@@ -34,11 +34,29 @@ class RiskConfig:
     daily_kill_switch_pct: float = -0.10
     min_collateral_usd: float = 20.0
 
+    # Confidence gate for opening/scaling positions.
+    min_confidence_to_trade: float = 0.60
+
+
+@dataclass
+class StrategyProfileConfig:
+    risk_pct: float | None = None
+    max_deployed_pct: float | None = None
+    max_leverage: float | None = None
+    min_confidence_to_trade: float | None = None
+
+    trend_weight_in_regime: float | None = None
+    adx_threshold: float | None = None
+    tie_break_to_trend: bool = False
+    tie_break_min_confidence: float = 0.0
+    regime_confidence_floor: float = 0.0
+
 
 @dataclass
 class StrategyConfig:
     default_id: str = DEFAULT_STRATEGY_ID
     allowed_ids: list[str] = field(default_factory=lambda: [DEFAULT_STRATEGY_ID])
+    profiles: dict[str, StrategyProfileConfig] = field(default_factory=dict)
 
 
 @dataclass
@@ -78,6 +96,7 @@ def load_config() -> BotConfig:
         max_deployed_pct=float(r.get("max_deployed_pct", cfg.risk.max_deployed_pct)),
         daily_kill_switch_pct=float(r.get("daily_kill_switch_pct", cfg.risk.daily_kill_switch_pct)),
         min_collateral_usd=float(r.get("min_collateral_usd", cfg.risk.min_collateral_usd)),
+        min_confidence_to_trade=float(r.get("min_confidence_to_trade", cfg.risk.min_confidence_to_trade)),
     )
 
     s = data.get("strategy", {}) or {}
@@ -92,7 +111,23 @@ def load_config() -> BotConfig:
     if default_id not in allowed_ids:
         allowed_ids.insert(0, default_id)
 
-    cfg.strategy = StrategyConfig(default_id=default_id, allowed_ids=allowed_ids)
+    profiles_raw = s.get("profiles", {}) or {}
+    profiles: dict[str, StrategyProfileConfig] = {}
+    for sid in allowed_ids:
+        raw = profiles_raw.get(sid, {}) or {}
+        profiles[sid] = StrategyProfileConfig(
+            risk_pct=(None if raw.get("risk_pct") is None else float(raw.get("risk_pct"))),
+            max_deployed_pct=(None if raw.get("max_deployed_pct") is None else float(raw.get("max_deployed_pct"))),
+            max_leverage=(None if raw.get("max_leverage") is None else float(raw.get("max_leverage"))),
+            min_confidence_to_trade=(None if raw.get("min_confidence_to_trade") is None else float(raw.get("min_confidence_to_trade"))),
+            trend_weight_in_regime=(None if raw.get("trend_weight_in_regime") is None else float(raw.get("trend_weight_in_regime"))),
+            adx_threshold=(None if raw.get("adx_threshold") is None else float(raw.get("adx_threshold"))),
+            tie_break_to_trend=bool(raw.get("tie_break_to_trend", False)),
+            tie_break_min_confidence=float(raw.get("tie_break_min_confidence", 0.0)),
+            regime_confidence_floor=float(raw.get("regime_confidence_floor", 0.0)),
+        )
+
+    cfg.strategy = StrategyConfig(default_id=default_id, allowed_ids=allowed_ids, profiles=profiles)
 
     return cfg
 

--- a/src/bot/risk.py
+++ b/src/bot/risk.py
@@ -145,7 +145,7 @@ def plan_from_signal(
     conf = float(getattr(signal, "confidence", 0.0) or 0.0)
 
     def _tiered_max(confidence: float) -> float:
-        if confidence < 0.60:
+        if confidence < cfg.min_confidence_to_trade:
             return 0.0
         if confidence < 0.74:
             return 2.0
@@ -176,7 +176,7 @@ def plan_from_signal(
             stop_loss=None,
             take_profit=None,
             risk_usd=0.0,
-            note=f"skip: conf={conf:.2f} below threshold ({signal.strategy})",
+            note=f"skip: conf={conf:.2f} below threshold={cfg.min_confidence_to_trade:.2f} ({signal.strategy})",
         )
 
     collateral = max(cfg.min_collateral_usd, target_notional / leverage)

--- a/src/bot/run_cycle.py
+++ b/src/bot/run_cycle.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -10,7 +10,7 @@ from .config import DEFAULT_STRATEGY_ID, as_dict, load_config
 from .models import PaperState, Position
 from .paper_engine import execute_paper
 from .risk import compute_risk_budget, plan_from_signal
-from .strategies import choose_signal
+from .strategies import StrategyConfig as SignalStrategyConfig, choose_signal
 from .storage import candles_path, journal_path, snapshot_path, state_path
 from .utils import jsonl_append, read_json, write_json
 
@@ -41,6 +41,40 @@ def _load_recent_candles(path: Path, limit: int = 200) -> list[dict[str, Any]]:
         except Exception:
             continue
     return out
+
+
+def _effective_risk_cfg(cfg, strategy_id: str):
+    p = cfg.strategy.profiles.get(strategy_id)
+    if p is None:
+        return cfg.risk
+
+    return replace(
+        cfg.risk,
+        risk_pct=(cfg.risk.risk_pct if p.risk_pct is None else p.risk_pct),
+        max_deployed_pct=(cfg.risk.max_deployed_pct if p.max_deployed_pct is None else p.max_deployed_pct),
+        max_leverage=(cfg.risk.max_leverage if p.max_leverage is None else p.max_leverage),
+        min_confidence_to_trade=(
+            cfg.risk.min_confidence_to_trade
+            if p.min_confidence_to_trade is None
+            else p.min_confidence_to_trade
+        ),
+    )
+
+
+def _effective_signal_cfg(cfg, strategy_id: str) -> SignalStrategyConfig:
+    p = cfg.strategy.profiles.get(strategy_id)
+    scfg = SignalStrategyConfig()
+    if p is None:
+        return scfg
+
+    if p.trend_weight_in_regime is not None:
+        scfg.trend_weight_in_regime = p.trend_weight_in_regime
+    if p.adx_threshold is not None:
+        scfg.adx_threshold = p.adx_threshold
+    scfg.tie_break_to_trend = p.tie_break_to_trend
+    scfg.tie_break_min_confidence = p.tie_break_min_confidence
+    scfg.regime_confidence_floor = p.regime_confidence_floor
+    return scfg
 
 
 def main() -> None:
@@ -92,17 +126,20 @@ def main() -> None:
 
     now_ts = int(datetime.now().timestamp())
 
-    rb = compute_risk_budget(float(paper.equity), cfg.risk)
+    effective_risk = _effective_risk_cfg(cfg, strategy_id)
+    signal_cfg = _effective_signal_cfg(cfg, strategy_id)
+
+    rb = compute_risk_budget(float(paper.equity), effective_risk)
     closes = [float(c["c"]) for c in candles if "c" in c]
     last_price = closes[-1] if closes else float(paper.last_price or 0.0)
 
-    sig = choose_signal(candles) if closes else None
+    sig = choose_signal(candles, cfg=signal_cfg) if closes else None
 
     if sig is None or last_price <= 0:
         plan = None
         action_note = "no candles yet"
     else:
-        plan = plan_from_signal(signal=sig, candles=candles, last_price=last_price, rb=rb, cfg=cfg.risk)
+        plan = plan_from_signal(signal=sig, candles=candles, last_price=last_price, rb=rb, cfg=effective_risk)
         # If we already have a position, upgrade open->scale/hold/flip/close based on direction.
         if paper.position is None:
             pass

--- a/src/bot/strategies.py
+++ b/src/bot/strategies.py
@@ -32,6 +32,11 @@ class StrategyConfig:
     min_spread_ratio: float = 0.0015  # |fast-slow|/slow
     min_slope_ratio: float = 0.0008
 
+    # Aggressive-mode knobs
+    tie_break_to_trend: bool = False
+    tie_break_min_confidence: float = 0.0
+    regime_confidence_floor: float = 0.0
+
 
 def trend_signal(closes: list[float], cfg: StrategyConfig) -> Signal:
     f = sma(closes, cfg.trend_fast)
@@ -125,11 +130,19 @@ def choose_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> Sig
 
     if long_score > short_score + 0.05:
         conf = min(1.0, long_score / (tw + mw))
+        if regime_on and cfg.regime_confidence_floor > 0:
+            conf = max(conf, cfg.regime_confidence_floor)
         return Signal(desired="long", confidence=conf, strategy="combo", note=f"weighted long ({regime_note})")
 
     if short_score > long_score + 0.05:
         conf = min(1.0, short_score / (tw + mw))
+        if regime_on and cfg.regime_confidence_floor > 0:
+            conf = max(conf, cfg.regime_confidence_floor)
         return Signal(desired="short", confidence=conf, strategy="combo", note=f"weighted short ({regime_note})")
 
     # tie/noisy area
+    if regime_on and cfg.tie_break_to_trend and t.desired in {"long", "short"} and t.confidence >= cfg.tie_break_min_confidence:
+        conf = max(t.confidence, cfg.regime_confidence_floor)
+        return Signal(desired=t.desired, confidence=min(1.0, conf), strategy="combo", note=f"regime tie-break via trend ({regime_note})")
+
     return Signal(desired="flat", confidence=0.4, strategy="combo", note=f"tie/noise ({regime_note})")

--- a/tests/test_strategy_foundation.py
+++ b/tests/test_strategy_foundation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from bot.storage import journal_path, snapshot_path, state_path
+
+
+def test_conservative_paths_remain_legacy() -> None:
+    d = "2026-03-10"
+    assert str(state_path()) == str(Path.cwd() / "data" / "state" / "current.json")
+    assert str(snapshot_path()) == str(Path.cwd() / "data" / "state" / "snapshot.json")
+    assert str(journal_path(d)) == str(Path.cwd() / "data" / "journal" / f"{d}.jsonl")
+
+
+def test_non_default_strategy_paths_are_isolated() -> None:
+    d = "2026-03-10"
+    sid = "aggressive"
+    assert str(state_path(sid)).endswith("data/strategies/aggressive/state/current.json")
+    assert str(snapshot_path(sid)).endswith("data/strategies/aggressive/state/snapshot.json")
+    assert str(journal_path(d, sid)).endswith(f"data/strategies/aggressive/journal/{d}.jsonl")
+
+
+def test_dashboard_unknown_strategy_falls_back_to_default() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    js = (
+        "import { normalizeStrategyId } from './dashboard/strategy.mjs';"
+        "const out = normalizeStrategyId('weird', ['conservative','aggressive'], 'conservative');"
+        "console.log(JSON.stringify({out}));"
+    )
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", js],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout.strip())
+    assert payload["out"] == "conservative"


### PR DESCRIPTION
## summary
Implements a focused #8 slice: deterministic aggressive profile controls, trend-regime tie-break behavior, and test scaffold promised after #16.

## what changed
### 1) strategy-specific config surface (deterministic + versionable)
- added `strategy.profiles` parsing in `src/bot/config.py`
- new profile knobs:
  - risk/exposure: `risk_pct`, `max_deployed_pct`, `max_leverage`, `min_confidence_to_trade`
  - signal/regime: `trend_weight_in_regime`, `adx_threshold`, `tie_break_to_trend`, `tie_break_min_confidence`, `regime_confidence_floor`
- `config.example.json` now includes an explicit `aggressive` profile block

### 2) aggressive-mode behavior in cycle/risk flow
- `run_cycle` now computes effective per-strategy risk + signal configs
- aggressive mode can:
  - lower confidence gate to trade
  - increase deployed-cap
  - apply trend tie-break in strong trend regimes (reduces flat/noise behavior)
  - apply confidence floor in confirmed regimes
- conservative defaults remain unchanged unless profile overrides are set

### 3) minimal test scaffold + promised compatibility checks
- added pytest dependency in `pyproject.toml` (`dev` extras)
- added `tests/test_strategy_foundation.py` covering:
  - legacy conservative storage paths
  - non-default strategy isolation paths
  - dashboard unknown `strategy_id` fallback behavior
- extracted dashboard strategy helpers to `dashboard/strategy.mjs` for testability

## validation
- `python3 -m compileall src/bot`
- `node --check dashboard/server.js`
- test scaffold added, but running `pytest` in this environment requires installing tooling (`pip`/`pytest`) not currently available in this host shell

Closes #8
