### PR TITLE
CI: enforce pytest compatibility checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install -e '.[dev]'
 
       - name: Ruff lint (automation surface)
         run: ruff check scripts
@@ -32,3 +32,6 @@ jobs:
 
       - name: Validate config baseline
         run: python scripts/validate_config.py
+
+      - name: Pytest compatibility checks
+        run: pytest -q

--- a/docs/REPO_UPDATE_PROCESS.md
+++ b/docs/REPO_UPDATE_PROCESS.md
@@ -15,7 +15,7 @@ This is the standard process for all updates.
 
 1. Open issue (bug/change/risk adjustment)
 2. Create branch from latest `main`
-3. Implement + test
+3. Implement + test (`python -m compileall -q src scripts` and `pytest -q`)
 4. Open PR using template
 5. Required review approval(s)
 6. Squash merge to `main`


### PR DESCRIPTION
## summary
Implements CI enforcement requested in #18 so compatibility tests introduced in #17 run on every PR.

## changes
- updated CI install step to install project dev dependencies:
  - `pip install -e '.[dev]'`
- added explicit pytest gate:
  - `pytest -q`
- updated contributor process doc (`docs/REPO_UPDATE_PROCESS.md`) to include local test command expectations.

## validation
- local compile smoke:
  - `python3 -m compileall -q src scripts`

Closes #18
