### PR TITLE
Benchmark panel: strategy return vs ETH buy-and-hold alpha

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,6 +5,7 @@ VPS dashboard/control plane (v1 mostly read-only) for **Avantis Paper Bot**.
 ## What v1 does (real functionality)
 - Reads snapshot + journal (JSON/JSONL) from the VPS.
 - Supports strategy-aware views (`strategy_id`) with side-by-side strategy snapshot cards.
+- Exposes benchmark metrics (`strategy_return`, `eth_bh_return`, `alpha`, `participation_ratio`) via API and UI.
 - Displays:
   - current position (flat/long/short + notional/leverage if present)
   - last cycle timestamp + note
@@ -17,6 +18,13 @@ VPS dashboard/control plane (v1 mostly read-only) for **Avantis Paper Bot**.
   - shows last mtime + minutes stale
 - Timeline:
   - last ~20 cycle events (from journal)
+
+## benchmark methodology (v1)
+- window: same UTC day + strategy lane
+- strategy return: `(latest_equity / first_cycle_equity) - 1`
+- ETH buy-and-hold return: `(latest_price / first_cycle_price) - 1`
+- alpha: `strategy_return - eth_bh_return`
+- participation ratio: `strategy_return / eth_bh_return` (null when denominator is ~0)
 
 ## What v1 does NOT do
 - No live trading.

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -312,6 +312,11 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
         <div><div class="muted">Win rate</div><strong id="repWinRate">—</strong></div>
         <div><div class="muted">Realized / Unrealized</div><strong id="repPnls">—</strong></div>
       </div>
+      <div class="grid3" style="margin-top:0.75rem;">
+        <div><div class="muted">Strategy return</div><strong id="repStratRet">—</strong></div>
+        <div><div class="muted">ETH buy-hold return</div><strong id="repEthRet">—</strong></div>
+        <div><div class="muted">Alpha / participation</div><strong id="repAlphaPart">—</strong></div>
+      </div>
     </section>
 
     <footer class="muted" style="margin: 2rem 0 2rem 0;">
@@ -516,6 +521,7 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
 
       grid.innerHTML = rows.map((r) => {
         const pos = r.status?.position?.label || 'flat';
+        const b = r.report.benchmark || {};
         return `
           <article class="card" style="margin:0; padding:0.75rem;">
             <div style="display:flex;justify-content:space-between;align-items:center;">
@@ -524,6 +530,7 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
             </div>
             <small class="muted">equity ${fmtMoney(r.status?.equity)} · daily ${fmtMoney(r.status?.daily_pnl)}</small>
             <div class="muted" style="margin-top:0.35rem;">trades ${r.report.tradeCount ?? 0} · win ${fmtPct(r.report.winRate)} · realized ${fmtMoney(r.report.realizedPnl)} · unrealized ${fmtMoney(r.report.unrealizedPnl)}</div>
+            <div class="muted" style="margin-top:0.35rem;">strat ${fmtPct(b.strategy_return)} · eth bh ${fmtPct(b.eth_bh_return)} · alpha ${fmtPct(b.alpha)}</div>
           </article>
         `;
       }).join('');
@@ -678,6 +685,10 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
       $('repTradeCount').textContent = (rs.tradeCount ?? '—');
       $('repWinRate').textContent = fmtPct(rs.winRate);
       $('repPnls').textContent = `${fmtMoney(rs.realizedPnl)} / ${fmtMoney(rs.unrealizedPnl)}`;
+      const b = rs.benchmark || {};
+      $('repStratRet').textContent = fmtPct(b.strategy_return);
+      $('repEthRet').textContent = fmtPct(b.eth_bh_return);
+      $('repAlphaPart').textContent = `${fmtPct(b.alpha)} / ${fmtNum(b.participation_ratio)}`;
 
       $('debug').textContent = JSON.stringify({ meta, statusRows, reportRows, status, timeline, report, chart, strategy }, null, 2);
     }

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -470,6 +470,60 @@ app.get('/api/chart', async (req, res) => {
   });
 });
 
+function computeBenchmarkFromCycles(cycles) {
+  if (!Array.isArray(cycles) || cycles.length < 2) {
+    return {
+      strategy_return: null,
+      eth_bh_return: null,
+      alpha: null,
+      participation_ratio: null,
+      start_equity: null,
+      end_equity: null,
+      start_price: null,
+      end_price: null,
+    };
+  }
+
+  const first = cycles[0];
+  const last = cycles[cycles.length - 1];
+
+  const startEquity = Number(first?.state?.equity);
+  const endEquity = Number(last?.state?.equity);
+  const startPrice = Number(first?.state?.last_price);
+  const endPrice = Number(last?.state?.last_price);
+
+  const strategyReturn =
+    Number.isFinite(startEquity) && Number.isFinite(endEquity) && startEquity > 0
+      ? endEquity / startEquity - 1.0
+      : null;
+
+  const ethBhReturn =
+    Number.isFinite(startPrice) && Number.isFinite(endPrice) && startPrice > 0
+      ? endPrice / startPrice - 1.0
+      : null;
+
+  const alpha =
+    strategyReturn !== null && ethBhReturn !== null
+      ? strategyReturn - ethBhReturn
+      : null;
+
+  const participationRatio =
+    strategyReturn !== null && ethBhReturn !== null && Math.abs(ethBhReturn) > 1e-9
+      ? strategyReturn / ethBhReturn
+      : null;
+
+  return {
+    strategy_return: strategyReturn,
+    eth_bh_return: ethBhReturn,
+    alpha,
+    participation_ratio: participationRatio,
+    start_equity: Number.isFinite(startEquity) ? startEquity : null,
+    end_equity: Number.isFinite(endEquity) ? endEquity : null,
+    start_price: Number.isFinite(startPrice) ? startPrice : null,
+    end_price: Number.isFinite(endPrice) ? endPrice : null,
+  };
+}
+
 app.get('/api/report/daily', async (req, res) => {
   const strategyId = normalizeStrategyId(req.query.strategy_id, STRATEGY_IDS, STRATEGY_DEFAULT_ID);
   const date = (req.query.date && String(req.query.date)) || utcDateString();
@@ -537,6 +591,8 @@ app.get('/api/report/daily', async (req, res) => {
       : notional * (price / entry - 1.0);
   }
 
+  const benchmark = computeBenchmarkFromCycles(cycles);
+
   res.json({
     ok: true,
     strategy_id: strategyId,
@@ -554,6 +610,7 @@ app.get('/api/report/daily', async (req, res) => {
       winRate: tradeCount > 0 ? winCount / tradeCount : null,
       realizedPnl,
       unrealizedPnl,
+      benchmark,
       candlesMinsStale,
       journalMinsStale,
       candlesNeeded,
@@ -562,6 +619,30 @@ app.get('/api/report/daily', async (req, res) => {
       feedStale: candlesMinsStale === null ? true : candlesMinsStale > STALE_MINUTES,
       cycleStale: journalMinsStale === null ? true : journalMinsStale > STALE_MINUTES
     }
+  });
+});
+
+app.get('/api/benchmark/daily', async (req, res) => {
+  const strategyId = normalizeStrategyId(req.query.strategy_id, STRATEGY_IDS, STRATEGY_DEFAULT_ID);
+  const date = (req.query.date && String(req.query.date)) || utcDateString();
+  const journalPath = await listJournalFile(date, strategyId);
+
+  let events = [];
+  try {
+    events = await tailJsonl(journalPath, 5000);
+  } catch {
+    events = [];
+  }
+
+  const cycles = events.filter((e) => e?.type === 'cycle');
+  const benchmark = computeBenchmarkFromCycles(cycles);
+
+  res.json({
+    ok: true,
+    strategy_id: strategyId,
+    date,
+    methodology: 'Uses same day window and start references as strategy state: first cycle equity/price vs latest cycle equity/price.',
+    benchmark,
   });
 });
 


### PR DESCRIPTION
## summary
Implements #10 by adding benchmark analytics (strategy vs ETH buy-and-hold) in both dashboard API and UI.

## what changed
- API additions:
  - added benchmark computation in daily report summary (`/api/report/daily`):
    - `strategy_return`
    - `eth_bh_return`
    - `alpha`
    - `participation_ratio`
  - added dedicated endpoint: `/api/benchmark/daily`
- UI additions:
  - strategy comparison cards now show strategy return vs ETH buy-and-hold + alpha
  - operator report now includes benchmark row for focused strategy:
    - strategy return
    - ETH buy-and-hold return
    - alpha / participation ratio
- docs:
  - updated `dashboard/README.md` with benchmark metrics + methodology

## methodology
- window: same UTC day and same strategy lane
- strategy return uses first vs latest cycle equity
- ETH buy-and-hold uses first vs latest cycle last_price
- alpha = strategy_return - eth_bh_return
- participation_ratio = strategy_return / eth_bh_return (null when denominator ~0)

## validation
- `node --check dashboard/server.js`
- `python3 -m compileall -q src`

Closes #10
