### PR TITLE
Docs: add paper runbook, strategy contract, and dashboard contract

### DIFF
--- a/docs/dashboard/DASHBOARD_CONTRACT_V1.md
+++ b/docs/dashboard/DASHBOARD_CONTRACT_V1.md
@@ -1,0 +1,65 @@
+# dashboard contract v1
+
+## metadata
+- version: v1.0.0
+- owner_role: dashboard_docs
+- review_cadence: weekly
+- next_review_due: 2026-03-17
+
+## objective
+Lock metric definitions and API/UI behavior to prevent drift between backend summaries and dashboard rendering.
+
+## endpoint contracts
+### `/api/statuses`
+- returns strategy-lane snapshot list
+- each row includes `strategy_id`, snapshot metadata, and extracted status
+
+### `/api/status?strategy_id=<id>`
+- returns focused status for selected strategy id
+- unknown id MUST normalize to default strategy id
+
+### `/api/report/daily?strategy_id=<id>&date=<YYYY-MM-DD>`
+summary fields include:
+- `tradeCount`
+- `winCount`
+- `lossCount`
+- `winRate`
+- `realizedPnl`
+- `unrealizedPnl`
+- `strategy_return`
+- `eth_bh_return`
+- `alpha`
+- `participation_ratio`
+
+## metric formulas
+- `winRate = winCount / tradeCount` (null when tradeCount = 0)
+- `alpha = strategy_return - eth_bh_return`
+- `participation_ratio = strategy_return / eth_bh_return` (null when denominator near zero)
+- `realizedPnl` (v1 proxy) derived from equity deltas on realized events (`close|flip`)
+- `unrealizedPnl` estimated from current position mark vs entry
+
+## methodology constraints
+- strategy and benchmark returns MUST use same UTC day window
+- strategy return uses first vs latest cycle equity
+- ETH buy-and-hold uses first vs latest cycle `last_price`
+
+## UI rendering rules
+- currency: 2 decimal places
+- percentages: one decimal place where shown
+- null values display as `—`
+- stale-state indicators must remain visible when source data ages beyond threshold
+- unknown strategy selection falls back to default id
+
+## compatibility policy
+- additive metrics are allowed if existing fields remain stable
+- breaking field removals/renames require contract version bump + migration notes
+- frontend must tolerate unknown extra fields without failing render
+
+## validation
+- compare API payload values against rendered UI for one selected day
+- verify conservative/aggressive focused views produce lane-consistent values
+- verify null/empty-state rendering on no-trade day
+
+## related issues
+- #9 strategy comparison view
+- #10 benchmark panel

--- a/docs/operations/RUNBOOK_PAPER_V1.md
+++ b/docs/operations/RUNBOOK_PAPER_V1.md
@@ -1,0 +1,104 @@
+# paper operations runbook v1
+
+## metadata
+- version: v1.0.0
+- owner_role: operations_docs
+- review_cadence: weekly
+- next_review_due: 2026-03-17
+
+## objective
+Provide executable, operator-first steps to start, verify, recover, and rollback the paper bot safely.
+
+## scope
+- paper-mode runtime (`apb-feed`, `apb-cycle`, `apb-dashboard`)
+- health verification and first-response recovery
+- rollback to last-known-good compose/image state
+
+## start checklist
+1. confirm branch/deploy source is merged `Main`.
+2. confirm config file exists and is valid:
+```bash
+python scripts/validate_config.py
+```
+3. start services:
+```bash
+docker compose up -d --build
+```
+4. confirm all services are running:
+```bash
+docker compose ps
+```
+
+## health verification (commands + expected output)
+### feed freshness
+```bash
+tail -n 2 data/candles/ETH-USD-15m.jsonl
+```
+Expected: recent closed-candle entries with increasing timestamps.
+
+### cycle freshness
+```bash
+tail -n 3 data/journal/$(date -u +%F).jsonl
+```
+Expected: cycle events with current UTC date and non-empty `plan/state` fields.
+
+### dashboard health
+```bash
+curl -s http://localhost:3030/api/status | jq '.ok, .status.equity, .status.position.label'
+```
+Expected: `true` and parseable status fields.
+
+## stop conditions (do NOT proceed)
+Stop deploy/ops progression immediately if any are true:
+- config validation fails
+- candles are stale > 2 cycles
+- cycle journal is not advancing
+- dashboard API parse errors persist after service restart
+- risk settings changed without reviewed PR and explicit approval
+
+## recovery playbooks
+### A) feed stale
+1. check feed logs:
+```bash
+docker compose logs --tail=200 apb-feed
+```
+2. restart feed service:
+```bash
+docker compose restart apb-feed
+```
+3. verify candle file updates within one cycle.
+
+### B) cycle stale
+1. inspect cycle logs:
+```bash
+docker compose logs --tail=200 apb-cycle
+```
+2. run one manual cycle command in container/shell context.
+3. if manual cycle succeeds, restart `apb-cycle`.
+
+### C) mount/path mismatch
+1. verify bind mounts in `docker-compose.yml`.
+2. confirm expected files exist under mounted `data/` path.
+3. restart services after correcting path mapping.
+
+## rollback path (last-known-good)
+1. identify last-known-good commit/image tag.
+2. revert compose/image refs to known-good.
+3. redeploy:
+```bash
+docker compose down
+docker compose up -d
+```
+4. rerun health verification section fully before declaring recovery.
+
+## post-incident evidence logging
+Record at minimum:
+- incident timestamp (UTC)
+- failure signature/log snippet
+- attempted actions + outcome
+- final resolution and rollback status
+- follow-up issue id
+
+## ownership
+- primary: boilermolt (docs/process)
+- technical runtime review: boilerclaw

--- a/docs/strategy/STRATEGY_CONTRACT_V1.md
+++ b/docs/strategy/STRATEGY_CONTRACT_V1.md
@@ -1,0 +1,73 @@
+# strategy contract v1
+
+## metadata
+- version: v1.0.0
+- owner_role: strategy_docs
+- review_cadence: weekly
+- next_review_due: 2026-03-17
+
+## objective
+Define auditable strategy-lane behavior and profile configuration for `conservative` and `aggressive` modes.
+
+## strategy ids and fallback
+- allowed ids come from `strategy.allowed_ids`
+- default id comes from `strategy.default_id`
+- unknown strategy id MUST normalize to default id at API/UI boundaries
+
+## profile schema (strategy.profiles.<id>)
+- `risk_pct`
+- `max_deployed_pct`
+- `max_leverage`
+- `min_confidence_to_trade`
+- `trend_weight_in_regime`
+- `adx_threshold`
+- `tie_break_to_trend`
+- `tie_break_min_confidence`
+- `regime_confidence_floor`
+
+If a field is omitted in profile, runtime MUST use global base risk/signal defaults.
+
+## non-overridable global risk boundaries
+Profile tuning MUST NOT bypass these invariants:
+- daily kill switch (`risk.daily_kill_switch_pct`)
+- min collateral floor (`risk.min_collateral_usd`)
+- hard leverage/deployment safety checks in runtime sizing path
+
+## config knob -> behavior mapping
+| knob | runtime effect |
+|---|---|
+| `min_confidence_to_trade` | lower than threshold => hold/skip |
+| `max_deployed_pct` | caps target notional vs equity |
+| `max_leverage` | caps leverage selected in tiered sizing |
+| `trend_weight_in_regime` | increases trend influence in regime resolver |
+| `adx_threshold` | controls regime activation sensitivity |
+| `tie_break_to_trend` | resolves tie/noise toward trend direction in regime |
+| `regime_confidence_floor` | minimum confidence in confirmed regime decisions |
+
+## required journaling fields
+Each cycle/trade artifact MUST include:
+- `strategy_id`
+- signal: desired/confidence/strategy/note
+- plan: action, leverage, risk_usd, stop/take fields
+- state: equity, daily_pnl, position, last_price
+
+## versioning + changelog
+### profile changelog
+- conservative v1.0.0: baseline defensive defaults
+- aggressive v1.0.0: lower confidence gate + higher deploy/risk profile with regime tie-break capability
+
+Any profile behavior change MUST:
+1. bump version (doc + config release note)
+2. include replay/validation evidence in PR
+3. annotate expected KPI impact
+
+## validation checklist
+- replay conservative vs aggressive on same window
+- compare exposure, drawdown, realized pnl, benchmark alpha
+- confirm fallback behavior for missing/unknown strategy id
+
+## related issues
+- #7 dual-strategy foundation
+- #8 aggressive mode v1
+- #9 strategy-side dashboard
+- #10 benchmark/alpha panel


### PR DESCRIPTION
## Summary
Implements the core docs contracts for operations, strategy, and dashboard surfaces.

## What changed
- added `docs/operations/RUNBOOK_PAPER_V1.md` (executable paper-ops runbook)
- added `docs/strategy/STRATEGY_CONTRACT_V1.md` (strategy/profile schema + risk boundaries + behavior mapping)
- added `docs/dashboard/DASHBOARD_CONTRACT_V1.md` (metric formulas, endpoint contracts, UI rendering rules, compatibility policy)

## Notes on issue mapping
- `RUNBOOK_PAPER_V1` implements #12 recommendations including stop conditions and recovery/rollback structure
- `STRATEGY_CONTRACT_V1` implements #13 must-haves around profile schema/versioning/non-overridable boundaries
- `DASHBOARD_CONTRACT_V1` implements #14 metric + endpoint + rendering contract requirements

## Validation
- markdown docs only; references verified against existing endpoints/fields introduced through #9/#10

## Risk impact
- docs only

Closes #12
Closes #13
Closes #14
