### PR TITLE
CI/docs: add minimal docs quality gate and checklist wiring

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,12 @@
 - [ ] infra/deploy
 - [ ] docs
 
+## Docs impact checklist (required when docs touched)
+- [ ] changed sections summary included
+- [ ] downstream docs touched listed (or `none`)
+- [ ] canonical docs index updated (or reason why not)
+- [ ] ran: `bash ./scripts/docs/check_docs.sh`
+
 ## Risk impact
 - [ ] no trading risk changes
 - [ ] includes trading risk changes (label `risk-change` required)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Validate config baseline
         run: python scripts/validate_config.py
 
+      - name: Docs quality gate
+        run: bash ./scripts/docs/check_docs.sh
+
       - name: Pytest compatibility checks
         run: pytest -q

--- a/docs/REPO_UPDATE_PROCESS.md
+++ b/docs/REPO_UPDATE_PROCESS.md
@@ -15,7 +15,7 @@ This is the standard process for all updates.
 
 1. Open issue (bug/change/risk adjustment)
 2. Create branch from latest `main`
-3. Implement + test (`python -m compileall -q src scripts` and `pytest -q`)
+3. Implement + test (`python -m compileall -q src scripts`, `bash ./scripts/docs/check_docs.sh`, and `pytest -q`)
 4. Open PR using template
 5. Required review approval(s)
 6. Squash merge to `main`

--- a/scripts/docs/check_docs.sh
+++ b/scripts/docs/check_docs.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail(){ echo "[docs-check][fail] $1"; exit 1; }
+warn(){ echo "[docs-check][warn] $1"; }
+pass(){ echo "[docs-check][pass] $1"; }
+
+# Minimal metadata gate for contract/runbook docs (v1 set)
+required_docs=(
+  "docs/operations/RUNBOOK_PAPER_V1.md"
+  "docs/strategy/STRATEGY_CONTRACT_V1.md"
+  "docs/dashboard/DASHBOARD_CONTRACT_V1.md"
+)
+
+for f in "${required_docs[@]}"; do
+  [[ -f "$f" ]] || { warn "$f missing (skip metadata check until doc exists)"; continue; }
+  grep -Eq '^## metadata' "$f" || fail "$f missing metadata section"
+  grep -Eq '^- version:' "$f" || fail "$f missing metadata: version"
+  grep -Eq '^- owner_role:' "$f" || fail "$f missing metadata: owner_role"
+  grep -Eq '^- review_cadence:' "$f" || fail "$f missing metadata: review_cadence"
+  grep -Eq '^- next_review_due:' "$f" || fail "$f missing metadata: next_review_due"
+  pass "$f metadata ok"
+done
+
+# Internal docs link integrity for backtick links (docs/*.md + dashboard/*.md)
+while IFS= read -r f; do
+  while IFS= read -r link; do
+    target=$(echo "$link" | sed -E 's/.*`([^`]+)`/\1/')
+    case "$target" in
+      docs/*.md|dashboard/*.md|README.md|boilerclaw/*.md)
+        [[ -f "$target" ]] || fail "$f references missing file: $target"
+        ;;
+    esac
+  done < <(grep -oE '`(docs/[^`]+\.md|dashboard/[^`]+\.md|README\.md|boilerclaw/[^`]+\.md)`' "$f" || true)
+done < <(find docs dashboard -type f -name '*.md' | sort)
+pass "internal docs links ok"
+
+# Canonical index cross-reference check (enabled when docs/README.md exists)
+INDEX="docs/README.md"
+if [[ -f "$INDEX" ]]; then
+  grep -Fq 'docs/architecture.md' "$INDEX" || fail "$INDEX missing cross-reference: docs/architecture.md"
+  grep -Fq 'docs/REPO_UPDATE_PROCESS.md' "$INDEX" || fail "$INDEX missing cross-reference: docs/REPO_UPDATE_PROCESS.md"
+  grep -Fq 'dashboard/README.md' "$INDEX" || fail "$INDEX missing cross-reference: dashboard/README.md"
+  pass "canonical index cross-references ok"
+else
+  warn "$INDEX missing; canonical index check skipped"
+fi
+
+pass "docs quality gate complete"

--- a/scripts/docs/check_docs.sh
+++ b/scripts/docs/check_docs.sh
@@ -44,6 +44,14 @@ if [[ -f "$INDEX" ]]; then
   grep -Fq 'docs/architecture.md' "$INDEX" || fail "$INDEX missing cross-reference: docs/architecture.md"
   grep -Fq 'docs/REPO_UPDATE_PROCESS.md' "$INDEX" || fail "$INDEX missing cross-reference: docs/REPO_UPDATE_PROCESS.md"
   grep -Fq 'dashboard/README.md' "$INDEX" || fail "$INDEX missing cross-reference: dashboard/README.md"
+
+  # When contract docs exist, index must reference them explicitly to prevent drift.
+  for f in "docs/operations/RUNBOOK_PAPER_V1.md" "docs/strategy/STRATEGY_CONTRACT_V1.md" "docs/dashboard/DASHBOARD_CONTRACT_V1.md"; do
+    if [[ -f "$f" ]]; then
+      grep -Fq "$f" "$INDEX" || fail "$INDEX missing cross-reference: $f"
+    fi
+  done
+
   pass "canonical index cross-references ok"
 else
   warn "$INDEX missing; canonical index check skipped"


### PR DESCRIPTION
## Summary
Implements #15 with a low-friction docs quality gate + PR checklist wiring.

## What changed
- added `scripts/docs/check_docs.sh` minimal gate:
  - metadata presence checks for contract/runbook docs (when present)
  - internal docs link integrity
  - canonical index cross-reference checks (when `docs/README.md` exists)
- wired docs gate into CI workflow (`.github/workflows/ci.yml`)
- added docs-impact checklist in PR template
- updated repo update process to include docs check command

## Design choice
This is intentionally a minimal first pass (warn/skip where docs are not yet present) to keep rollout low-noise, with stricter enforcement planned in a follow-up pass.

## Validation
- `bash ./scripts/docs/check_docs.sh`
- `python3 -m compileall -q src scripts`

## Risk impact
- docs/ci process only

Closes #15
