### PR TITLE
Benchmark UX: add low-sample confidence warning

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -25,6 +25,7 @@ VPS dashboard/control plane (v1 mostly read-only) for **Avantis Paper Bot**.
 - ETH buy-and-hold return: `(latest_price / first_cycle_price) - 1`
 - alpha: `strategy_return - eth_bh_return`
 - participation ratio: `strategy_return / eth_bh_return` (null when denominator is ~0)
+- low-sample confidence flag: `low_sample=true` when `cycle_count < min_cycle_count_for_confidence` (default: 24 cycles)
 
 ## What v1 does NOT do
 - No live trading.

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -317,6 +317,7 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
         <div><div class="muted">ETH buy-hold return</div><strong id="repEthRet">—</strong></div>
         <div><div class="muted">Alpha / participation</div><strong id="repAlphaPart">—</strong></div>
       </div>
+      <div class="muted" id="repSampleNote" style="margin-top:0.55rem;">—</div>
     </section>
 
     <footer class="muted" style="margin: 2rem 0 2rem 0;">
@@ -531,6 +532,7 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
             <small class="muted">equity ${fmtMoney(r.status?.equity)} · daily ${fmtMoney(r.status?.daily_pnl)}</small>
             <div class="muted" style="margin-top:0.35rem;">trades ${r.report.tradeCount ?? 0} · win ${fmtPct(r.report.winRate)} · realized ${fmtMoney(r.report.realizedPnl)} · unrealized ${fmtMoney(r.report.unrealizedPnl)}</div>
             <div class="muted" style="margin-top:0.35rem;">strat ${fmtPct(b.strategy_return)} · eth bh ${fmtPct(b.eth_bh_return)} · alpha ${fmtPct(b.alpha)}</div>
+            ${b.low_sample ? `<div class="muted" style="margin-top:0.35rem;"><span class="pill">low sample</span> ${b.sample_note || ''}</div>` : ''}
           </article>
         `;
       }).join('');
@@ -689,6 +691,7 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
       $('repStratRet').textContent = fmtPct(b.strategy_return);
       $('repEthRet').textContent = fmtPct(b.eth_bh_return);
       $('repAlphaPart').textContent = `${fmtPct(b.alpha)} / ${fmtNum(b.participation_ratio)}`;
+      $('repSampleNote').textContent = b.low_sample ? `⚠️ ${b.sample_note || 'Interpret alpha cautiously; sample size is low.'}` : 'sample confidence looks sufficient.';
 
       $('debug').textContent = JSON.stringify({ meta, statusRows, reportRows, status, timeline, report, chart, strategy }, null, 2);
     }

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -470,9 +470,17 @@ app.get('/api/chart', async (req, res) => {
   });
 });
 
-function computeBenchmarkFromCycles(cycles) {
+function computeBenchmarkFromCycles(cycles, minCycleCountForConfidence = 24) {
+  const cycleCount = Array.isArray(cycles) ? cycles.length : 0;
   if (!Array.isArray(cycles) || cycles.length < 2) {
+    const lowSample = cycleCount < minCycleCountForConfidence;
     return {
+      cycle_count: cycleCount,
+      min_cycle_count_for_confidence: minCycleCountForConfidence,
+      low_sample: lowSample,
+      sample_note: lowSample
+        ? `Interpret benchmark cautiously: only ${cycleCount} cycles (< ${minCycleCountForConfidence}).`
+        : null,
       strategy_return: null,
       eth_bh_return: null,
       alpha: null,
@@ -512,7 +520,15 @@ function computeBenchmarkFromCycles(cycles) {
       ? strategyReturn / ethBhReturn
       : null;
 
+  const lowSample = cycleCount < minCycleCountForConfidence;
+
   return {
+    cycle_count: cycleCount,
+    min_cycle_count_for_confidence: minCycleCountForConfidence,
+    low_sample: lowSample,
+    sample_note: lowSample
+      ? `Interpret benchmark cautiously: only ${cycleCount} cycles (< ${minCycleCountForConfidence}).`
+      : null,
     strategy_return: strategyReturn,
     eth_bh_return: ethBhReturn,
     alpha,

--- a/docs/dashboard/DASHBOARD_CONTRACT_V1.md
+++ b/docs/dashboard/DASHBOARD_CONTRACT_V1.md
@@ -26,10 +26,14 @@ summary fields include:
 - `winRate`
 - `realizedPnl`
 - `unrealizedPnl`
-- `strategy_return`
-- `eth_bh_return`
-- `alpha`
-- `participation_ratio`
+- `benchmark.cycle_count`
+- `benchmark.min_cycle_count_for_confidence`
+- `benchmark.low_sample`
+- `benchmark.sample_note`
+- `benchmark.strategy_return`
+- `benchmark.eth_bh_return`
+- `benchmark.alpha`
+- `benchmark.participation_ratio`
 
 ## metric formulas
 - `winRate = winCount / tradeCount` (null when tradeCount = 0)
@@ -49,6 +53,7 @@ summary fields include:
 - null values display as `—`
 - stale-state indicators must remain visible when source data ages beyond threshold
 - unknown strategy selection falls back to default id
+- if `benchmark.low_sample=true`, UI shows a neutral caution note (not a hard error)
 
 ## compatibility policy
 - additive metrics are allowed if existing fields remain stable


### PR DESCRIPTION
## summary
Implements #22 by adding low-sample confidence context for daily benchmark interpretation.

## what changed
- API benchmark payload now includes:
  - `cycle_count`
  - `min_cycle_count_for_confidence` (default 24)
  - `low_sample` (boolean)
  - `sample_note`
- included above fields in benchmark object used by:
  - `/api/report/daily`
  - `/api/benchmark/daily`
- UI updates:
  - strategy comparison cards show a neutral `low sample` badge/note when applicable
  - focused report panel shows contextual caution note (not error)
- docs updates:
  - `docs/dashboard/DASHBOARD_CONTRACT_V1.md` benchmark field contract + rendering rule
  - `dashboard/README.md` methodology note for low-sample threshold

## validation
- `node --check dashboard/server.js`
- `bash ./scripts/docs/check_docs.sh`
- `python3 -m compileall -q src scripts`

Closes #22
