### PR TITLE
fix: wire aggressive strategy rendering in dashboard (issue #27)

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -562,7 +562,7 @@ Defaults (seed): 1% equity risk, clamp $10-$50, max lev 2x, max deployed 75%, da
       const timeline = await fetch(`/api/timeline?strategy_id=${encodeURIComponent(currentStrategyId)}&date=${encodeURIComponent(utcDate())}&max=200`).then(r => r.json());
       const report = reportRows[currentStrategyId] || await fetch(`/api/report/daily?strategy_id=${encodeURIComponent(currentStrategyId)}&date=${encodeURIComponent(utcDate())}`).then(r => r.json());
       const chart = await fetch(`/api/chart?strategy_id=${encodeURIComponent(currentStrategyId)}&date=${encodeURIComponent(utcDate())}`).then(r => r.json());
-      const strategy = await fetch('/api/strategy').then(r => r.json());
+      const strategy = await fetch(`/api/strategy?strategy_id=${encodeURIComponent(currentStrategyId)}`).then(r => r.json());
 
       // Health
       const snapOk = status.snapshot && !status.snapshot.isStale && status.snapshot.stat && status.snapshot.stat.ok && !status.snapshot.parseError;

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -208,9 +208,10 @@ function startDataMountSelfHeal() {
   }, intervalMs);
 }
 
-app.get('/api/strategy', async (_req, res) => {
+app.get('/api/strategy', async (req, res) => {
+  const strategyId = normalizeStrategyId(req.query.strategy_id, STRATEGY_IDS, STRATEGY_DEFAULT_ID);
   const date = utcDateString();
-  const journalPath = await listJournalFile(date);
+  const journalPath = await listJournalFile(date, strategyId);
 
   let latestCycle = null;
   try {
@@ -223,6 +224,7 @@ app.get('/api/strategy', async (_req, res) => {
 
   res.json({
     ok: true,
+    strategy_id: strategyId,
     strategy: STRATEGY_DEFAULTS,
     latestSignal: latestCycle ? {
       desired: latestCycle?.signal?.desired ?? null,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       SNAPSHOT_PATH: /var/lib/avantis-paper-bot/data/state/snapshot.json
       JOURNAL_DIR: /var/lib/avantis-paper-bot/data/journal
       CANDLES_PATH: /var/lib/avantis-paper-bot/data/candles/ETH-USD-15m.jsonl
+      STRATEGY_DEFAULT_ID: conservative
+      STRATEGY_IDS: conservative,aggressive
     volumes:
       - apb_data:/var/lib/avantis-paper-bot/data:ro
     restart: unless-stopped


### PR DESCRIPTION
Closes #27

## Scope
- Lane: dashboard + compose wiring
- Fixes strategy wiring so aggressive data can render in selector/compare/focused panels.

## What changed
1) `docker-compose.yml`
- Added dashboard env wiring:
  - `STRATEGY_DEFAULT_ID=conservative`
  - `STRATEGY_IDS=conservative,aggressive`

2) `dashboard/server.js`
- `/api/strategy` now accepts `strategy_id` and reads the matching journal file.
- Response now includes `strategy_id` for debug clarity.

3) `dashboard/public/index.html`
- Strategy panel now requests `/api/strategy?strategy_id=<selected>` so latest signal/note follow focused strategy.

## Validation
- `node --check dashboard/server.js`
- Manual code-path verification for selected strategy propagation:
  - UI select -> `/api/strategy?strategy_id=...` -> server journal lookup by strategy id

## Risk
- Low: read-only dashboard wiring only, no trading/runtime decision logic changed.

## Rollback
- Revert this PR commit to restore prior single-strategy default behavior.
