### PR TITLE
feat: add super_aggressive profile + cycle service (issue #29)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -4,7 +4,7 @@
 
   "strategy": {
     "default_id": "conservative",
-    "allowed_ids": ["conservative", "aggressive"],
+    "allowed_ids": ["conservative", "aggressive", "super_aggressive"],
     "profiles": {
       "conservative": {},
       "aggressive": {
@@ -17,6 +17,17 @@
         "tie_break_to_trend": true,
         "tie_break_min_confidence": 0.18,
         "regime_confidence_floor": 0.28
+      },
+      "super_aggressive": {
+        "risk_pct": 0.08,
+        "max_deployed_pct": 0.95,
+        "max_leverage": 2.0,
+        "min_confidence_to_trade": 0.20,
+        "trend_weight_in_regime": 2.2,
+        "adx_threshold": 14.0,
+        "tie_break_to_trend": true,
+        "tie_break_min_confidence": 0.14,
+        "regime_confidence_floor": 0.22
       }
     }
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       JOURNAL_DIR: /var/lib/avantis-paper-bot/data/journal
       CANDLES_PATH: /var/lib/avantis-paper-bot/data/candles/ETH-USD-15m.jsonl
       STRATEGY_DEFAULT_ID: conservative
-      STRATEGY_IDS: conservative,aggressive
+      STRATEGY_IDS: conservative,aggressive,super_aggressive
     volumes:
       - apb_data:/var/lib/avantis-paper-bot/data:ro
     restart: unless-stopped
@@ -36,6 +36,40 @@ services:
         "sh",
         "-lc",
         "while true; do python -m bot.run_cycle --pair 'ETH/USD' --tf-min 15; sleep 900; done",
+      ]
+    environment:
+      APB_DATA_DIR: /var/lib/avantis-paper-bot/data
+      APB_CONFIG: /var/lib/avantis-paper-bot/bootstrap.json
+    volumes:
+      - apb_data:/var/lib/avantis-paper-bot/data
+      - ./config.example.json:/var/lib/avantis-paper-bot/bootstrap.json:ro
+    restart: unless-stopped
+
+  apb-cycle-aggressive:
+    build: .
+    image: avantis-paper-bot:latest
+    command:
+      [
+        "sh",
+        "-lc",
+        "while true; do python -m bot.run_cycle --pair 'ETH/USD' --tf-min 15 --strategy-id aggressive; sleep 900; done",
+      ]
+    environment:
+      APB_DATA_DIR: /var/lib/avantis-paper-bot/data
+      APB_CONFIG: /var/lib/avantis-paper-bot/bootstrap.json
+    volumes:
+      - apb_data:/var/lib/avantis-paper-bot/data
+      - ./config.example.json:/var/lib/avantis-paper-bot/bootstrap.json:ro
+    restart: unless-stopped
+
+  apb-cycle-super-aggressive:
+    build: .
+    image: avantis-paper-bot:latest
+    command:
+      [
+        "sh",
+        "-lc",
+        "while true; do python -m bot.run_cycle --pair 'ETH/USD' --tf-min 15 --strategy-id super_aggressive; sleep 900; done",
       ]
     environment:
       APB_DATA_DIR: /var/lib/avantis-paper-bot/data


### PR DESCRIPTION
Closes #29

## Scope
- Add paper-only `super_aggressive` strategy lane.
- Keep existing TP + trailing-stop behavior (already in paper engine) and run it as a dedicated cycle service.

## What changed
1) `config.example.json`
- Added `super_aggressive` to `strategy.allowed_ids`.
- Added `strategy.profiles.super_aggressive` with higher-risk paper profile params.

2) `docker-compose.yml`
- Dashboard strategy list expanded to:
  - `STRATEGY_IDS=conservative,aggressive,super_aggressive`
- Added/kept dedicated cycle services:
  - `apb-cycle` (default conservative)
  - `apb-cycle-aggressive`
  - `apb-cycle-super-aggressive`

## TP + trailing-stop note
No code change required here: paper engine already applies
- partial TP at 1.5R
- trailing stop on remaining size
for all strategy lanes, including `super_aggressive`.

## Validation
- JSON parse + config load from `config.example.json`
- strategy ids resolve: `conservative`, `aggressive`, `super_aggressive`

## Risk
- Medium ops (extra container/service load), low trading-risk impact (paper only).

## Rollback
- Revert this PR commit to remove `super_aggressive` lane and service.
