### PR TITLE
feat: add edge_filtered fourth paper strategy lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ python -m bot.feed_listener --pair "ETH/USD" --tf-min 15
 ```bash
 python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id conservative
 python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id aggressive
+python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id super_aggressive
+python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id edge_filtered
 ```
 
 ---
@@ -118,6 +120,9 @@ risk controls are explicit and should be treated as first-class change surfaces:
 
 strategy behavior can be profile-driven (`strategy.profiles`), so aggressive mode can use
 higher deployment + lower confidence gates while conservative remains unchanged.
+
+`edge_filtered` is an additive paper experiment lane using a stricter confidence gate
+(`min_confidence_to_trade: 0.60`) to skip lower-conviction entries.
 
 any change to these should go through reviewed PRs only.
 

--- a/config.example.json
+++ b/config.example.json
@@ -4,7 +4,7 @@
 
   "strategy": {
     "default_id": "conservative",
-    "allowed_ids": ["conservative", "aggressive", "super_aggressive"],
+    "allowed_ids": ["conservative", "aggressive", "super_aggressive", "edge_filtered"],
     "profiles": {
       "conservative": {},
       "aggressive": {
@@ -28,6 +28,17 @@
         "tie_break_to_trend": true,
         "tie_break_min_confidence": 0.14,
         "regime_confidence_floor": 0.22
+      },
+      "edge_filtered": {
+        "risk_pct": 0.05,
+        "max_deployed_pct": 0.90,
+        "max_leverage": 2.0,
+        "min_confidence_to_trade": 0.60,
+        "trend_weight_in_regime": 1.8,
+        "adx_threshold": 16.0,
+        "tie_break_to_trend": true,
+        "tie_break_min_confidence": 0.18,
+        "regime_confidence_floor": 0.28
       }
     }
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       JOURNAL_DIR: /var/lib/avantis-paper-bot/data/journal
       CANDLES_PATH: /var/lib/avantis-paper-bot/data/candles/ETH-USD-15m.jsonl
       STRATEGY_DEFAULT_ID: conservative
-      STRATEGY_IDS: conservative,aggressive,super_aggressive
+      STRATEGY_IDS: conservative,aggressive,super_aggressive,edge_filtered
     volumes:
       - apb_data:/var/lib/avantis-paper-bot/data:ro
     restart: unless-stopped
@@ -70,6 +70,23 @@ services:
         "sh",
         "-lc",
         "while true; do python -m bot.run_cycle --pair 'ETH/USD' --tf-min 15 --strategy-id super_aggressive; sleep 900; done",
+      ]
+    environment:
+      APB_DATA_DIR: /var/lib/avantis-paper-bot/data
+      APB_CONFIG: /var/lib/avantis-paper-bot/bootstrap.json
+    volumes:
+      - apb_data:/var/lib/avantis-paper-bot/data
+      - ./config.example.json:/var/lib/avantis-paper-bot/bootstrap.json:ro
+    restart: unless-stopped
+
+  apb-cycle-edge-filtered:
+    build: .
+    image: avantis-paper-bot:latest
+    command:
+      [
+        "sh",
+        "-lc",
+        "while true; do python -m bot.run_cycle --pair 'ETH/USD' --tf-min 15 --strategy-id edge_filtered; sleep 900; done",
       ]
     environment:
       APB_DATA_DIR: /var/lib/avantis-paper-bot/data


### PR DESCRIPTION
## scope
- add `edge_filtered` to strategy allow-list and profile config
- set `edge_filtered.min_confidence_to_trade` to `0.60`
- add dedicated compose service `apb-cycle-edge-filtered`
- include `edge_filtered` in dashboard `STRATEGY_IDS`
- update README strategy run examples + experiment note

## risk
low blast radius; additive-only config/compose/docs changes, no runtime logic mutation for existing lanes.

## validation
- `python3 -m compileall -q src`
- `docker compose config`
- manual diff confirms existing conservative/aggressive/super_aggressive service commands unchanged

## rollback
- revert this PR commit to remove the fourth lane and restore prior config/compose state.

Closes #32
