### PR TITLE
feat: deterministic replay harness for fixed-window strategy evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id super_aggress
 python -m bot.run_cycle --pair "ETH/USD" --tf-min 15 --strategy-id edge_filtered
 ```
 
+### 4) run a deterministic fixed-window replay
+
+```bash
+python3 -m bot.replay \
+  --pair "ETH/USD" \
+  --tf-min 15 \
+  --strategy-id conservative \
+  --compare-strategy-id aggressive \
+  --candles-file data/candles/ETH-USD-15m.jsonl \
+  --start-ts 1700000000 \
+  --end-ts 1700863200
+```
+
+artifacts are written under `data/replays/<pair>-<tf>m/<start>-<end>/...` with stable names:
+- `manifest.json`
+- `summary.json`
+- `cycles.jsonl`
+- `trades.jsonl`
+- `equity.jsonl`
+
+the replay path uses stored candles only, records skips/vetoes plus regime/setup labels, and avoids volatile timestamps in diff-critical outputs.
+
 ---
 
 ## docker deployment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,17 @@ This repo is a **paper-first** scaffold for trading **Avantis perps** (starting 
    - Writes dashboard snapshot:
      - `data/state/snapshot.json`
 
+3) `bot.replay` (offline fixed-window evaluation)
+   - Loads stored candles from JSONL only
+   - Replays one strategy, or two strategies on the same frozen window, without feed or live execution dependencies
+   - Writes deterministic artifacts under `data/replays/...`:
+     - `manifest.json`
+     - `summary.json`
+     - `cycles.jsonl`
+     - `trades.jsonl`
+     - `equity.jsonl`
+   - Artifact rows include regime labels, setup labels, skips/vetoes, execution events, and strategy/config fingerprints
+
 ## What decides long vs short?
 
 ### Signals (`src/bot/strategies.py`)
@@ -83,6 +94,33 @@ The journal is JSONL with one event per cycle:
 A "trade event" is inferred when:
 - `plan.action != "hold"` OR
 - `state.position` changes vs previous cycle
+
+## Replay artifact contract (v0)
+
+The replay harness is the deterministic evidence path for strategy evaluation on a fixed candle window.
+
+- `manifest.json`
+  - replay contract version
+  - symbol/timeframe/window
+  - strategy id + strategy/config fingerprint
+  - effective risk/signal config snapshot
+- `summary.json`
+  - ending equity / net pnl / return
+  - max drawdown
+  - decision counts (`trade`, `skip`, `veto`)
+  - regime and setup coverage counts
+- `cycles.jsonl`
+  - one deterministic decision row per candle in the scored window
+  - includes signal, plan, regime/setup labels, risk budget, execution events, and resulting paper state
+- `trades.jsonl`
+  - flattened execution events (`open`, `close`, `flip_*`, `stop_loss`, `take_profit_partial`, `scale`)
+- `equity.jsonl`
+  - replay equity curve aligned to the fixed candle window
+
+Boundary for this first slice:
+- one symbol/timeframe per replay
+- one candle file per replay
+- same-window two-strategy comparison is supported via paired single-strategy bundles plus one comparison JSON
 
 ## AI / Agent involvement
 

--- a/docs/strategy/EXPERIMENTATION_FRAMEWORK_V1.md
+++ b/docs/strategy/EXPERIMENTATION_FRAMEWORK_V1.md
@@ -193,8 +193,8 @@ If someone reads the repo later, they should be able to answer: what was tested,
 Issue `#34` is satisfied when this framework exists in-repo as the initial operating document and future strategy work can point back to it.
 
 Follow-on issues should then:
-- implement replay/evidence tooling
-- implement deterministic review artifacts
+- expand replay/evidence tooling beyond the fixed-window deterministic harness
+- refine deterministic review artifacts/comparison bundles
 - refine promotion policy and governance details
 - revise this framework when real usage reveals gaps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 [project.scripts]
 apb-feed = "bot.feed_listener:main"
 apb-cycle = "bot.run_cycle:main"
+apb-replay = "bot.replay:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/bot/paper_engine.py
+++ b/src/bot/paper_engine.py
@@ -8,7 +8,21 @@ Adds basic in-position trade management:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from .models import OrderPlan, PaperState, Position
+
+
+@dataclass
+class ExecutionEvent:
+    ts: int
+    kind: str
+    side: str
+    fill_price: float
+    notional_usd: float
+    pnl_usd: float
+    equity_after: float
+    note: str = ""
 
 
 def apply_slippage(price: float, slip_bps: float, side: str) -> float:
@@ -25,7 +39,15 @@ def _realize_pnl(pos: Position, fill_price: float, close_notional: float) -> flo
     return close_notional * (pos.avg_price / fill_price - 1.0)
 
 
-def open_position(state: PaperState, plan: OrderPlan, fill_price: float, ts: int) -> PaperState:
+def open_position(
+    state: PaperState,
+    plan: OrderPlan,
+    fill_price: float,
+    ts: int,
+    *,
+    events: list[ExecutionEvent] | None = None,
+    kind: str = "open",
+) -> PaperState:
     trail_distance = abs(fill_price - plan.stop_loss) if plan.stop_loss is not None else None
     pos = Position(
         side=plan.side or "long",
@@ -42,10 +64,32 @@ def open_position(state: PaperState, plan: OrderPlan, fill_price: float, ts: int
         trail_distance=trail_distance,
     )
     state.position = pos
+    if events is not None:
+        events.append(
+            ExecutionEvent(
+                ts=ts,
+                kind=kind,
+                side=pos.side,
+                fill_price=fill_price,
+                notional_usd=plan.target_notional_usd,
+                pnl_usd=0.0,
+                equity_after=state.equity,
+                note=plan.note,
+            )
+        )
     return state
 
 
-def close_position(state: PaperState, fill_price: float, close_notional: float | None = None) -> PaperState:
+def close_position(
+    state: PaperState,
+    fill_price: float,
+    close_notional: float | None = None,
+    *,
+    ts: int | None = None,
+    events: list[ExecutionEvent] | None = None,
+    kind: str = "close",
+    note: str = "",
+) -> PaperState:
     pos = state.position
     if not pos:
         return state
@@ -54,6 +98,7 @@ def close_position(state: PaperState, fill_price: float, close_notional: float |
     pnl = _realize_pnl(pos, fill_price, amount)
     state.equity += pnl
     state.daily_pnl += pnl
+    side = pos.side
 
     pos.notional_usd -= amount
     if pos.notional_usd <= 1e-9:
@@ -63,10 +108,30 @@ def close_position(state: PaperState, fill_price: float, close_notional: float |
         if pos.leverage > 0:
             pos.collateral_usd = pos.notional_usd / pos.leverage
         state.position = pos
+    if events is not None and ts is not None:
+        events.append(
+            ExecutionEvent(
+                ts=ts,
+                kind=kind,
+                side=side,
+                fill_price=fill_price,
+                notional_usd=amount,
+                pnl_usd=pnl,
+                equity_after=state.equity,
+                note=note,
+            )
+        )
     return state
 
 
-def scale_position(state: PaperState, plan: OrderPlan, fill_price: float) -> PaperState:
+def scale_position(
+    state: PaperState,
+    plan: OrderPlan,
+    fill_price: float,
+    *,
+    ts: int | None = None,
+    events: list[ExecutionEvent] | None = None,
+) -> PaperState:
     pos = state.position
     if not pos:
         return state
@@ -85,10 +150,30 @@ def scale_position(state: PaperState, plan: OrderPlan, fill_price: float) -> Pap
     pos.take_profit = plan.take_profit
     if pos.initial_notional_usd is None:
         pos.initial_notional_usd = target
+    if events is not None and ts is not None:
+        events.append(
+            ExecutionEvent(
+                ts=ts,
+                kind="scale",
+                side=pos.side,
+                fill_price=fill_price,
+                notional_usd=add,
+                pnl_usd=0.0,
+                equity_after=state.equity,
+                note=plan.note,
+            )
+        )
     return state
 
 
-def _manage_position(state: PaperState, last_price: float, slip_bps: float) -> PaperState:
+def _manage_position(
+    state: PaperState,
+    last_price: float,
+    slip_bps: float,
+    *,
+    ts: int,
+    events: list[ExecutionEvent] | None = None,
+) -> PaperState:
     pos = state.position
     if not pos:
         return state
@@ -97,7 +182,7 @@ def _manage_position(state: PaperState, last_price: float, slip_bps: float) -> P
     if pos.stop_loss is not None:
         if (pos.side == "long" and last_price <= pos.stop_loss) or (pos.side == "short" and last_price >= pos.stop_loss):
             fill = apply_slippage(last_price, slip_bps, side=pos.side)
-            return close_position(state, fill)
+            return close_position(state, fill, ts=ts, events=events, kind="stop_loss", note="hard stop")
 
     # 2) one-time partial at TP (50%)
     if not pos.partial_taken and pos.take_profit is not None:
@@ -106,7 +191,15 @@ def _manage_position(state: PaperState, last_price: float, slip_bps: float) -> P
             fill = apply_slippage(last_price, slip_bps, side=pos.side)
             close_amt = (pos.initial_notional_usd or pos.notional_usd) * 0.5
             close_amt = min(close_amt, pos.notional_usd)
-            state = close_position(state, fill, close_notional=close_amt)
+            state = close_position(
+                state,
+                fill,
+                close_notional=close_amt,
+                ts=ts,
+                events=events,
+                kind="take_profit_partial",
+                note="partial take profit",
+            )
             if state.position:
                 state.position.partial_taken = True
             return state
@@ -128,39 +221,61 @@ def _manage_position(state: PaperState, last_price: float, slip_bps: float) -> P
 
 
 def execute_paper(state: PaperState, plan: OrderPlan, last_price: float, slip_bps: float, ts: int) -> PaperState:
+    state, _ = execute_paper_with_events(state, plan, last_price=last_price, slip_bps=slip_bps, ts=ts)
+    return state
+
+
+def execute_paper_with_events(
+    state: PaperState,
+    plan: OrderPlan,
+    last_price: float,
+    slip_bps: float,
+    ts: int,
+) -> tuple[PaperState, list[ExecutionEvent]]:
+    events: list[ExecutionEvent] = []
     state.last_price = last_price
 
     # Always enforce in-position management first.
-    state = _manage_position(state, last_price=last_price, slip_bps=slip_bps)
+    state = _manage_position(state, last_price=last_price, slip_bps=slip_bps, ts=ts, events=events)
 
     if plan.action == "hold":
-        return state
+        return state, events
 
     if plan.action == "close":
         if state.position:
             fill = apply_slippage(last_price, slip_bps, side=state.position.side)
-            return close_position(state, fill)
-        return state
+            return (
+                close_position(state, fill, ts=ts, events=events, kind="close", note=plan.note),
+                events,
+            )
+        return state, events
 
     if plan.action == "open":
         if plan.side is None:
-            return state
+            return state, events
         fill = apply_slippage(last_price, slip_bps, side=plan.side)
-        return open_position(state, plan, fill, ts)
+        return open_position(state, plan, fill, ts, events=events, kind="open"), events
 
     if plan.action == "flip":
         if state.position:
             fill_close = apply_slippage(last_price, slip_bps, side=state.position.side)
-            state = close_position(state, fill_close)
+            state = close_position(
+                state,
+                fill_close,
+                ts=ts,
+                events=events,
+                kind="flip_close",
+                note=plan.note,
+            )
         if plan.side is None:
-            return state
+            return state, events
         fill_open = apply_slippage(last_price, slip_bps, side=plan.side)
-        return open_position(state, plan, fill_open, ts)
+        return open_position(state, plan, fill_open, ts, events=events, kind="flip_open"), events
 
     if plan.action == "scale":
         if not state.position or plan.side is None:
-            return state
+            return state, events
         fill = apply_slippage(last_price, slip_bps, side=plan.side)
-        return scale_position(state, plan, fill)
+        return scale_position(state, plan, fill, ts=ts, events=events), events
 
-    return state
+    return state, events

--- a/src/bot/replay.py
+++ b/src/bot/replay.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import DEFAULT_STRATEGY_ID, as_dict, load_config
+from .paper_engine import execute_paper_with_events
+from .risk import compute_risk_budget, plan_from_signal
+from .runtime import default_paper_state, effective_risk_cfg, effective_signal_cfg, paper_state_from_raw
+from .storage import candles_path
+from .strategies import SignalAnalysis, analyze_signal
+from .utils import data_dir, jsonl_write, stable_json_dumps, write_json_stable
+
+
+@dataclass
+class ReplayBundle:
+    strategy_id: str
+    fingerprint: str
+    output_dir: Path
+    manifest: dict[str, Any]
+    summary: dict[str, Any]
+    cycles: list[dict[str, Any]]
+    trades: list[dict[str, Any]]
+    equity_curve: list[dict[str, Any]]
+
+
+def _sanitize_pair(pair: str) -> str:
+    return pair.replace("/", "-").replace(" ", "")
+
+
+def _load_candles(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"missing candles file: {path}")
+
+    rows: list[tuple[int, dict[str, Any]]] = []
+    for idx, line in enumerate(path.read_text(encoding="utf-8").splitlines()):
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        rows.append((idx, payload))
+
+    rows.sort(key=lambda item: (int(item[1].get("start_ts", 0)), item[0]))
+    return [row for _, row in rows]
+
+
+def _window_candles(
+    candles: list[dict[str, Any]],
+    *,
+    start_ts: int | None,
+    end_ts: int | None,
+) -> tuple[list[dict[str, Any]], int, int]:
+    selected = [
+        candle
+        for candle in candles
+        if (start_ts is None or int(candle.get("start_ts", 0)) >= start_ts)
+        and (end_ts is None or int(candle.get("start_ts", 0)) <= end_ts)
+    ]
+    if not selected:
+        raise ValueError("no candles matched the requested replay window")
+
+    first_ts = int(selected[0]["start_ts"])
+    last_ts = int(selected[-1]["start_ts"])
+    return selected, first_ts, last_ts
+
+
+def _strategy_fingerprint(strategy_id: str, effective_risk, signal_cfg) -> str:
+    payload = {
+        "strategy_id": strategy_id,
+        "risk": as_dict(effective_risk),
+        "signal": as_dict(signal_cfg),
+    }
+    return hashlib.sha256(stable_json_dumps(payload).encode("utf-8")).hexdigest()[:12]
+
+
+def _artifact_dir(
+    *,
+    output_root: Path,
+    pair: str,
+    tf_min: int,
+    strategy_id: str,
+    fingerprint: str,
+    start_ts: int,
+    end_ts: int,
+) -> Path:
+    pair_slug = _sanitize_pair(pair)
+    return output_root / f"{pair_slug}-{tf_min}m" / f"{start_ts}-{end_ts}" / f"{strategy_id}-{fingerprint}"
+
+
+def _decision_record(signal_analysis: SignalAnalysis, plan) -> dict[str, Any]:
+    if plan.action != "hold":
+        status = "trade"
+        reason = plan.action
+    elif signal_analysis.signal.desired == "flat":
+        status = "skip"
+        reason = "signal_flat"
+    elif signal_analysis.setup_label == "no_trade":
+        status = "skip"
+        reason = "no_setup"
+    else:
+        status = "veto"
+        reason = "risk_gate"
+
+    return {
+        "status": status,
+        "reason": reason,
+        "signal_desired": signal_analysis.signal.desired,
+        "plan_action": plan.action,
+    }
+
+
+def _paper_state_dict(state) -> dict[str, Any]:
+    return {
+        "equity": state.equity,
+        "daily_pnl": state.daily_pnl,
+        "position": (None if state.position is None else as_dict(state.position)),
+        "last_price": state.last_price,
+    }
+
+
+def _max_drawdown(equity_curve: list[dict[str, Any]]) -> float:
+    peak = None
+    max_dd = 0.0
+    for point in equity_curve:
+        equity = float(point["equity"])
+        if peak is None or equity > peak:
+            peak = equity
+        if peak and peak > 0:
+            max_dd = max(max_dd, (peak - equity) / peak)
+    return max_dd
+
+
+def replay_fixed_window(
+    *,
+    strategy_id: str,
+    candles_file: Path,
+    pair: str,
+    tf_min: int,
+    output_root: Path,
+    start_ts: int | None = None,
+    end_ts: int | None = None,
+    initial_equity: float = 100.0,
+    slip_bps: float = 2.0,
+) -> ReplayBundle:
+    cfg = load_config()
+    strategy_id = (strategy_id or DEFAULT_STRATEGY_ID).strip()
+    if strategy_id not in cfg.strategy.allowed_ids:
+        raise ValueError(f"strategy_id '{strategy_id}' not allowed; allowed_ids={cfg.strategy.allowed_ids}")
+
+    all_candles = _load_candles(candles_file)
+    window_candles, window_start_ts, window_end_ts = _window_candles(
+        all_candles,
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+    by_ts = {int(candle["start_ts"]): idx for idx, candle in enumerate(all_candles)}
+
+    effective_risk = effective_risk_cfg(cfg, strategy_id)
+    signal_cfg = effective_signal_cfg(cfg, strategy_id)
+    fingerprint = _strategy_fingerprint(strategy_id, effective_risk, signal_cfg)
+    output_dir = _artifact_dir(
+        output_root=output_root,
+        pair=pair,
+        tf_min=tf_min,
+        strategy_id=strategy_id,
+        fingerprint=fingerprint,
+        start_ts=window_start_ts,
+        end_ts=window_end_ts,
+    )
+
+    raw_state = default_paper_state(strategy_id)
+    raw_state["equity"] = float(initial_equity)
+    state = paper_state_from_raw(raw_state)
+
+    cycles: list[dict[str, Any]] = []
+    trades: list[dict[str, Any]] = []
+    equity_curve: list[dict[str, Any]] = []
+    skip_counter: Counter[str] = Counter()
+    setup_counter: Counter[str] = Counter()
+    regime_counter: Counter[str] = Counter()
+
+    for candle in window_candles:
+        candle_ts = int(candle["start_ts"])
+        candle_idx = by_ts[candle_ts]
+        history = all_candles[: candle_idx + 1]
+        last_price = float(candle["c"])
+        rb = compute_risk_budget(float(state.equity), effective_risk)
+        analysis = analyze_signal(history, cfg=signal_cfg)
+        plan = plan_from_signal(
+            signal=analysis.signal,
+            candles=history,
+            last_price=last_price,
+            rb=rb,
+            cfg=effective_risk,
+        )
+
+        if state.position is not None:
+            if analysis.signal.desired == "flat":
+                plan.action = "close"
+                plan.side = state.position.side
+            else:
+                desired_side = "long" if analysis.signal.desired == "long" else "short"
+                if desired_side != state.position.side:
+                    plan.action = "flip"
+                    plan.side = desired_side
+                else:
+                    plan.action = "hold"
+                    plan.side = desired_side
+
+        state, execution_events = execute_paper_with_events(
+            state,
+            plan,
+            last_price=last_price,
+            slip_bps=slip_bps,
+            ts=candle_ts,
+        )
+        decision = _decision_record(analysis, plan)
+        skip_counter[decision["status"]] += 1
+        setup_counter[analysis.setup_label] += 1
+        regime_counter[analysis.regime_label] += 1
+
+        execution_payload = [asdict(event) for event in execution_events]
+        trades.extend(execution_payload)
+        equity_curve.append(
+            {
+                "ts": candle_ts,
+                "equity": state.equity,
+                "daily_pnl": state.daily_pnl,
+                "position_side": (None if state.position is None else state.position.side),
+                "position_notional_usd": (0.0 if state.position is None else state.position.notional_usd),
+            }
+        )
+        cycles.append(
+            {
+                "ts": candle_ts,
+                "candle": {
+                    "start_ts": candle_ts,
+                    "o": float(candle["o"]),
+                    "h": float(candle["h"]),
+                    "l": float(candle["l"]),
+                    "c": last_price,
+                    "tf_sec": int(candle.get("tf_sec", tf_min * 60)),
+                },
+                "analysis": {
+                    "regime_label": analysis.regime_label,
+                    "regime_note": analysis.regime_note,
+                    "setup_label": analysis.setup_label,
+                    "trend_signal": as_dict(analysis.trend_signal),
+                    "mean_reversion_signal": as_dict(analysis.mean_reversion_signal),
+                },
+                "signal": as_dict(analysis.signal),
+                "plan": as_dict(plan),
+                "decision": decision,
+                "risk_budget": as_dict(rb),
+                "execution_events": execution_payload,
+                "state": _paper_state_dict(state),
+            }
+        )
+
+    summary = {
+        "strategy_id": strategy_id,
+        "fingerprint": fingerprint,
+        "pair": pair,
+        "tf_min": tf_min,
+        "window": {
+            "start_ts": window_start_ts,
+            "end_ts": window_end_ts,
+            "candles": len(window_candles),
+        },
+        "initial_equity": initial_equity,
+        "ending_equity": state.equity,
+        "net_pnl": state.equity - initial_equity,
+        "return_pct": (0.0 if initial_equity == 0 else (state.equity / initial_equity - 1.0)),
+        "max_drawdown_pct": _max_drawdown(equity_curve),
+        "decision_counts": dict(sorted(skip_counter.items())),
+        "setup_counts": dict(sorted(setup_counter.items())),
+        "regime_counts": dict(sorted(regime_counter.items())),
+        "execution_event_count": len(trades),
+        "trade_count": sum(1 for trade in trades if trade["kind"] in {"open", "flip_open", "scale"}),
+        "close_count": sum(
+            1 for trade in trades if trade["kind"] in {"close", "flip_close", "stop_loss", "take_profit_partial"}
+        ),
+    }
+    manifest = {
+        "contract_version": "replay.v1",
+        "strategy_id": strategy_id,
+        "fingerprint": fingerprint,
+        "pair": pair,
+        "tf_min": tf_min,
+        "window": summary["window"],
+        "inputs": {
+            "candles_file": str(candles_file),
+            "slip_bps": slip_bps,
+            "initial_equity": initial_equity,
+        },
+        "effective_config": {
+            "risk": as_dict(effective_risk),
+            "signal": as_dict(signal_cfg),
+        },
+        "artifacts": {
+            "summary": "summary.json",
+            "manifest": "manifest.json",
+            "cycles": "cycles.jsonl",
+            "trades": "trades.jsonl",
+            "equity_curve": "equity.jsonl",
+        },
+    }
+
+    write_json_stable(output_dir / "manifest.json", manifest)
+    write_json_stable(output_dir / "summary.json", summary)
+    jsonl_write(output_dir / "cycles.jsonl", cycles, stable=True)
+    jsonl_write(output_dir / "trades.jsonl", trades, stable=True)
+    jsonl_write(output_dir / "equity.jsonl", equity_curve, stable=True)
+
+    return ReplayBundle(
+        strategy_id=strategy_id,
+        fingerprint=fingerprint,
+        output_dir=output_dir,
+        manifest=manifest,
+        summary=summary,
+        cycles=cycles,
+        trades=trades,
+        equity_curve=equity_curve,
+    )
+
+
+def write_comparison(output_root: Path, baseline: ReplayBundle, candidate: ReplayBundle) -> Path:
+    comparison = {
+        "contract_version": "replay-compare.v1",
+        "window": baseline.summary["window"],
+        "baseline": {
+            "strategy_id": baseline.strategy_id,
+            "fingerprint": baseline.fingerprint,
+            "summary": baseline.summary,
+            "artifact_dir": str(baseline.output_dir),
+        },
+        "candidate": {
+            "strategy_id": candidate.strategy_id,
+            "fingerprint": candidate.fingerprint,
+            "summary": candidate.summary,
+            "artifact_dir": str(candidate.output_dir),
+        },
+        "delta": {
+            "net_pnl": candidate.summary["net_pnl"] - baseline.summary["net_pnl"],
+            "return_pct": candidate.summary["return_pct"] - baseline.summary["return_pct"],
+            "max_drawdown_pct": candidate.summary["max_drawdown_pct"] - baseline.summary["max_drawdown_pct"],
+            "trade_count": candidate.summary["trade_count"] - baseline.summary["trade_count"],
+            "close_count": candidate.summary["close_count"] - baseline.summary["close_count"],
+        },
+        "boundary": "Comparison is deterministic for one symbol/timeframe/window under one candle file and one config snapshot.",
+    }
+    path = (
+        output_root
+        / f"{_sanitize_pair(baseline.summary['pair'])}-{baseline.summary['tf_min']}m"
+        / f"{baseline.summary['window']['start_ts']}-{baseline.summary['window']['end_ts']}"
+        / f"compare-{baseline.strategy_id}-vs-{candidate.strategy_id}.json"
+    )
+    write_json_stable(path, comparison)
+    return path
+
+
+def main() -> None:
+    cfg = load_config()
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pair", default=cfg.pair)
+    ap.add_argument("--tf-min", type=int, default=cfg.tf_min)
+    ap.add_argument("--strategy-id", default=cfg.strategy.default_id)
+    ap.add_argument("--compare-strategy-id", default=None)
+    ap.add_argument("--candles-file", default=None)
+    ap.add_argument("--start-ts", type=int, default=None)
+    ap.add_argument("--end-ts", type=int, default=None)
+    ap.add_argument("--initial-equity", type=float, default=100.0)
+    ap.add_argument("--slip-bps", type=float, default=2.0)
+    ap.add_argument("--output-dir", default=str(data_dir() / "replays"))
+    args = ap.parse_args()
+
+    candle_file = Path(args.candles_file) if args.candles_file else candles_path(args.pair, args.tf_min)
+    output_root = Path(args.output_dir)
+
+    primary = replay_fixed_window(
+        strategy_id=args.strategy_id,
+        candles_file=candle_file,
+        pair=args.pair,
+        tf_min=args.tf_min,
+        output_root=output_root,
+        start_ts=args.start_ts,
+        end_ts=args.end_ts,
+        initial_equity=args.initial_equity,
+        slip_bps=args.slip_bps,
+    )
+
+    print(f"[replay] strategy={primary.strategy_id} artifacts={primary.output_dir}")
+
+    if args.compare_strategy_id:
+        compare = replay_fixed_window(
+            strategy_id=args.compare_strategy_id,
+            candles_file=candle_file,
+            pair=args.pair,
+            tf_min=args.tf_min,
+            output_root=output_root,
+            start_ts=args.start_ts,
+            end_ts=args.end_ts,
+            initial_equity=args.initial_equity,
+            slip_bps=args.slip_bps,
+        )
+        comparison_path = write_comparison(output_root, primary, compare)
+        print(
+            f"[replay] comparison baseline={primary.strategy_id} candidate={compare.strategy_id} file={comparison_path}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bot/risk.py
+++ b/src/bot/risk.py
@@ -162,7 +162,7 @@ def plan_from_signal(
     if "mean_reversion" in strat:
         tier_cap = min(tier_cap, 3.0)
 
-    max_lev_allowed = min(cfg.max_leverage, tier_cap if tier_cap > 0 else cfg.max_leverage)
+    max_lev_allowed = 0.0 if tier_cap <= 0 else min(cfg.max_leverage, tier_cap)
 
     leverage = min(max_lev_allowed, max(1.0, target_notional / cfg.min_collateral_usd))
     # If tiering says "skip", force a hold.

--- a/src/bot/run_cycle.py
+++ b/src/bot/run_cycle.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from .config import DEFAULT_STRATEGY_ID, as_dict, load_config
-from .models import PaperState, Position
 from .paper_engine import execute_paper
 from .risk import compute_risk_budget, plan_from_signal
-from .strategies import StrategyConfig as SignalStrategyConfig, choose_signal
+from .runtime import default_paper_state, effective_risk_cfg, effective_signal_cfg, paper_state_from_raw
+from .strategies import choose_signal
 from .storage import candles_path, journal_path, snapshot_path, state_path
 from .utils import jsonl_append, read_json, write_json
 
@@ -43,40 +43,6 @@ def _load_recent_candles(path: Path, limit: int = 200) -> list[dict[str, Any]]:
     return out
 
 
-def _effective_risk_cfg(cfg, strategy_id: str):
-    p = cfg.strategy.profiles.get(strategy_id)
-    if p is None:
-        return cfg.risk
-
-    return replace(
-        cfg.risk,
-        risk_pct=(cfg.risk.risk_pct if p.risk_pct is None else p.risk_pct),
-        max_deployed_pct=(cfg.risk.max_deployed_pct if p.max_deployed_pct is None else p.max_deployed_pct),
-        max_leverage=(cfg.risk.max_leverage if p.max_leverage is None else p.max_leverage),
-        min_confidence_to_trade=(
-            cfg.risk.min_confidence_to_trade
-            if p.min_confidence_to_trade is None
-            else p.min_confidence_to_trade
-        ),
-    )
-
-
-def _effective_signal_cfg(cfg, strategy_id: str) -> SignalStrategyConfig:
-    p = cfg.strategy.profiles.get(strategy_id)
-    scfg = SignalStrategyConfig()
-    if p is None:
-        return scfg
-
-    if p.trend_weight_in_regime is not None:
-        scfg.trend_weight_in_regime = p.trend_weight_in_regime
-    if p.adx_threshold is not None:
-        scfg.adx_threshold = p.adx_threshold
-    scfg.tie_break_to_trend = p.tie_break_to_trend
-    scfg.tie_break_min_confidence = p.tie_break_min_confidence
-    scfg.regime_confidence_floor = p.regime_confidence_floor
-    return scfg
-
-
 def main() -> None:
     cfg = load_config()
 
@@ -96,33 +62,8 @@ def main() -> None:
     cpath = candles_path(args.pair, args.tf_min)
     candles = _load_recent_candles(cpath, limit=args.candle_limit)
 
-    raw_state = read_json(state_path(strategy_id), default={"equity": 100.0, "position": None, "daily_pnl": 0.0})
-
-    # normalize to PaperState
-    pos_raw = raw_state.get("position")
-    pos = None
-    if isinstance(pos_raw, dict):
-        pos = Position(
-            side=pos_raw.get("side"),
-            notional_usd=float(pos_raw.get("notional_usd", 0.0)),
-            collateral_usd=float(pos_raw.get("collateral_usd", 0.0)),
-            leverage=float(pos_raw.get("leverage", 0.0)),
-            entry_price=float(pos_raw.get("entry_price", 0.0)),
-            avg_price=float(pos_raw.get("avg_price", pos_raw.get("entry_price", 0.0))),
-            stop_loss=pos_raw.get("stop_loss"),
-            take_profit=pos_raw.get("take_profit"),
-            opened_ts=int(pos_raw.get("opened_ts", 0)),
-            initial_notional_usd=(None if pos_raw.get("initial_notional_usd") is None else float(pos_raw.get("initial_notional_usd"))),
-            partial_taken=bool(pos_raw.get("partial_taken", False)),
-            trail_distance=(None if pos_raw.get("trail_distance") is None else float(pos_raw.get("trail_distance"))),
-        )
-
-    paper = PaperState(
-        equity=float(raw_state.get("equity", 0.0)),
-        daily_pnl=float(raw_state.get("daily_pnl", 0.0)),
-        position=pos,
-        last_price=raw_state.get("last_price"),
-    )
+    raw_state = read_json(state_path(strategy_id), default=default_paper_state(strategy_id))
+    paper = paper_state_from_raw(raw_state)
 
     now_ts = int(datetime.now().timestamp())
 

--- a/src/bot/runtime.py
+++ b/src/bot/runtime.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .config import DEFAULT_STRATEGY_ID
+from .models import PaperState, Position
+from .strategies import StrategyConfig as SignalStrategyConfig
+
+
+def effective_risk_cfg(cfg, strategy_id: str):
+    p = cfg.strategy.profiles.get(strategy_id)
+    if p is None:
+        return cfg.risk
+
+    return replace(
+        cfg.risk,
+        risk_pct=(cfg.risk.risk_pct if p.risk_pct is None else p.risk_pct),
+        max_deployed_pct=(cfg.risk.max_deployed_pct if p.max_deployed_pct is None else p.max_deployed_pct),
+        max_leverage=(cfg.risk.max_leverage if p.max_leverage is None else p.max_leverage),
+        min_confidence_to_trade=(
+            cfg.risk.min_confidence_to_trade
+            if p.min_confidence_to_trade is None
+            else p.min_confidence_to_trade
+        ),
+    )
+
+
+def effective_signal_cfg(cfg, strategy_id: str) -> SignalStrategyConfig:
+    p = cfg.strategy.profiles.get(strategy_id)
+    scfg = SignalStrategyConfig()
+    if p is None:
+        return scfg
+
+    if p.trend_weight_in_regime is not None:
+        scfg.trend_weight_in_regime = p.trend_weight_in_regime
+    if p.adx_threshold is not None:
+        scfg.adx_threshold = p.adx_threshold
+    scfg.tie_break_to_trend = p.tie_break_to_trend
+    scfg.tie_break_min_confidence = p.tie_break_min_confidence
+    scfg.regime_confidence_floor = p.regime_confidence_floor
+    return scfg
+
+
+def paper_state_from_raw(raw_state: dict) -> PaperState:
+    pos_raw = raw_state.get("position")
+    pos = None
+    if isinstance(pos_raw, dict):
+        pos = Position(
+            side=pos_raw.get("side"),
+            notional_usd=float(pos_raw.get("notional_usd", 0.0)),
+            collateral_usd=float(pos_raw.get("collateral_usd", 0.0)),
+            leverage=float(pos_raw.get("leverage", 0.0)),
+            entry_price=float(pos_raw.get("entry_price", 0.0)),
+            avg_price=float(pos_raw.get("avg_price", pos_raw.get("entry_price", 0.0))),
+            stop_loss=pos_raw.get("stop_loss"),
+            take_profit=pos_raw.get("take_profit"),
+            opened_ts=int(pos_raw.get("opened_ts", 0)),
+            initial_notional_usd=(
+                None
+                if pos_raw.get("initial_notional_usd") is None
+                else float(pos_raw.get("initial_notional_usd"))
+            ),
+            partial_taken=bool(pos_raw.get("partial_taken", False)),
+            trail_distance=(
+                None if pos_raw.get("trail_distance") is None else float(pos_raw.get("trail_distance"))
+            ),
+        )
+
+    return PaperState(
+        equity=float(raw_state.get("equity", 0.0)),
+        daily_pnl=float(raw_state.get("daily_pnl", 0.0)),
+        position=pos,
+        last_price=raw_state.get("last_price"),
+    )
+
+
+def default_paper_state(strategy_id: str = DEFAULT_STRATEGY_ID) -> dict:
+    return {
+        "strategy_id": strategy_id,
+        "equity": 100.0,
+        "position": None,
+        "daily_pnl": 0.0,
+        "last_price": None,
+    }

--- a/src/bot/strategies.py
+++ b/src/bot/strategies.py
@@ -38,6 +38,16 @@ class StrategyConfig:
     regime_confidence_floor: float = 0.0
 
 
+@dataclass
+class SignalAnalysis:
+    signal: Signal
+    trend_signal: Signal
+    mean_reversion_signal: Signal
+    regime_label: str
+    regime_note: str
+    setup_label: str
+
+
 def trend_signal(closes: list[float], cfg: StrategyConfig) -> Signal:
     f = sma(closes, cfg.trend_fast)
     s = sma(closes, cfg.trend_slow)
@@ -96,24 +106,48 @@ def _trend_regime(closes: list[float], highs: list[float], lows: list[float], cf
     return ok, f"adx={a:.1f} spread={spread:.4f} slope={slope:.4f}"
 
 
-def choose_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> Signal:
+def analyze_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> SignalAnalysis:
     cfg = cfg or StrategyConfig()
     closes = [float(c["c"]) for c in candles if "c" in c]
     highs = [float(c["h"]) for c in candles if "h" in c]
     lows = [float(c["l"]) for c in candles if "l" in c]
 
     if not closes:
-        return Signal(desired="flat", confidence=0.0, strategy="combo", note="no candles")
+        empty = Signal(desired="flat", confidence=0.0, strategy="combo", note="no candles")
+        return SignalAnalysis(
+            signal=empty,
+            trend_signal=Signal(desired="flat", confidence=0.0, strategy="trend", note="no candles"),
+            mean_reversion_signal=Signal(
+                desired="flat",
+                confidence=0.0,
+                strategy="mean_reversion",
+                note="no candles",
+            ),
+            regime_label="unknown",
+            regime_note="no candles",
+            setup_label="no_trade",
+        )
 
     t = trend_signal(closes, cfg)
     m = mean_reversion_signal(closes, cfg)
     regime_on, regime_note = _trend_regime(closes, highs, lows, cfg)
+    if regime_on and t.desired == "long":
+        regime_label = "trend_up"
+    elif regime_on and t.desired == "short":
+        regime_label = "trend_down"
+    elif t.note.startswith("insufficient") or m.note.startswith("insufficient"):
+        regime_label = "unknown"
+    elif m.desired in {"long", "short"}:
+        regime_label = "range"
+    else:
+        regime_label = "transition"
 
     tw = cfg.trend_weight_in_regime if regime_on else cfg.trend_weight
     mw = cfg.mr_weight
 
     long_score = 0.0
     short_score = 0.0
+    setup_label = "no_trade"
 
     if t.desired == "long":
         long_score += t.confidence * tw
@@ -126,23 +160,84 @@ def choose_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> Sig
         short_score += m.confidence * mw
 
     if long_score <= 0 and short_score <= 0:
-        return Signal(desired="flat", confidence=0.35, strategy="combo", note=f"both flat | {regime_note}")
+        signal = Signal(desired="flat", confidence=0.35, strategy="combo", note=f"both flat | {regime_note}")
+        return SignalAnalysis(
+            signal=signal,
+            trend_signal=t,
+            mean_reversion_signal=m,
+            regime_label=regime_label,
+            regime_note=regime_note,
+            setup_label=setup_label,
+        )
 
     if long_score > short_score + 0.05:
         conf = min(1.0, long_score / (tw + mw))
         if regime_on and cfg.regime_confidence_floor > 0:
             conf = max(conf, cfg.regime_confidence_floor)
-        return Signal(desired="long", confidence=conf, strategy="combo", note=f"weighted long ({regime_note})")
+        if t.desired == "long" and m.desired == "long":
+            setup_label = "trend_plus_mean_reversion_long"
+        elif t.desired == "long":
+            setup_label = "trend_follow_long"
+        elif m.desired == "long":
+            setup_label = "mean_reversion_long"
+        signal = Signal(desired="long", confidence=conf, strategy="combo", note=f"weighted long ({regime_note})")
+        return SignalAnalysis(
+            signal=signal,
+            trend_signal=t,
+            mean_reversion_signal=m,
+            regime_label=regime_label,
+            regime_note=regime_note,
+            setup_label=setup_label,
+        )
 
     if short_score > long_score + 0.05:
         conf = min(1.0, short_score / (tw + mw))
         if regime_on and cfg.regime_confidence_floor > 0:
             conf = max(conf, cfg.regime_confidence_floor)
-        return Signal(desired="short", confidence=conf, strategy="combo", note=f"weighted short ({regime_note})")
+        if t.desired == "short" and m.desired == "short":
+            setup_label = "trend_plus_mean_reversion_short"
+        elif t.desired == "short":
+            setup_label = "trend_follow_short"
+        elif m.desired == "short":
+            setup_label = "mean_reversion_short"
+        signal = Signal(desired="short", confidence=conf, strategy="combo", note=f"weighted short ({regime_note})")
+        return SignalAnalysis(
+            signal=signal,
+            trend_signal=t,
+            mean_reversion_signal=m,
+            regime_label=regime_label,
+            regime_note=regime_note,
+            setup_label=setup_label,
+        )
 
     # tie/noisy area
     if regime_on and cfg.tie_break_to_trend and t.desired in {"long", "short"} and t.confidence >= cfg.tie_break_min_confidence:
         conf = max(t.confidence, cfg.regime_confidence_floor)
-        return Signal(desired=t.desired, confidence=min(1.0, conf), strategy="combo", note=f"regime tie-break via trend ({regime_note})")
+        signal = Signal(
+            desired=t.desired,
+            confidence=min(1.0, conf),
+            strategy="combo",
+            note=f"regime tie-break via trend ({regime_note})",
+        )
+        return SignalAnalysis(
+            signal=signal,
+            trend_signal=t,
+            mean_reversion_signal=m,
+            regime_label=regime_label,
+            regime_note=regime_note,
+            setup_label="regime_tie_break",
+        )
 
-    return Signal(desired="flat", confidence=0.4, strategy="combo", note=f"tie/noise ({regime_note})")
+    signal = Signal(desired="flat", confidence=0.4, strategy="combo", note=f"tie/noise ({regime_note})")
+    return SignalAnalysis(
+        signal=signal,
+        trend_signal=t,
+        mean_reversion_signal=m,
+        regime_label=regime_label,
+        regime_note=regime_note,
+        setup_label=setup_label,
+    )
+
+
+def choose_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> Signal:
+    return analyze_signal(candles, cfg).signal

--- a/src/bot/utils.py
+++ b/src/bot/utils.py
@@ -33,9 +33,37 @@ def json_dumps(obj: Any) -> str:
     )
 
 
+def stable_json_dumps(obj: Any) -> str:
+    return json.dumps(
+        obj,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+        default=_json_default,
+    ) + "\n"
+
+
+def stable_jsonl_dumps(obj: Any) -> str:
+    return json.dumps(
+        obj,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=_json_default,
+    ) + "\n"
+
+
 def jsonl_append(path: Path, obj: Any) -> None:
     ensure_parent(path)
     path.open("a", encoding="utf-8").write(json_dumps(obj) + "\n")
+
+
+def jsonl_write(path: Path, rows: list[Any], *, stable: bool = False) -> None:
+    ensure_parent(path)
+    dumps = stable_jsonl_dumps if stable else lambda value: json_dumps(value) + "\n"
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(dumps(row))
 
 
 def read_json(path: Path, default: Any) -> Any:
@@ -48,3 +76,8 @@ def read_json(path: Path, default: Any) -> Any:
 def write_json(path: Path, obj: Any) -> None:
     ensure_parent(path)
     path.write_text(json.dumps(obj, indent=2, ensure_ascii=False, default=_json_default) + "\n", encoding="utf-8")
+
+
+def write_json_stable(path: Path, obj: Any) -> None:
+    ensure_parent(path)
+    path.write_text(stable_json_dumps(obj), encoding="utf-8")

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bot.replay import replay_fixed_window, write_comparison
+
+
+def _write_fixture_files(tmp_path: Path) -> tuple[Path, Path]:
+    config = {
+        "pair": "ETH/USD",
+        "tf_min": 15,
+        "risk": {"min_confidence_to_trade": 0.60},
+        "strategy": {
+            "default_id": "conservative",
+            "allowed_ids": ["conservative", "aggressive"],
+            "profiles": {
+                "aggressive": {"regime_confidence_floor": 0.70},
+            },
+        },
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    price = 100.0
+    candles = []
+    for i in range(80):
+        if i < 30:
+            price += 0.05
+        elif i < 55:
+            price += 0.9
+        else:
+            price -= 1.1
+        candles.append(
+            {
+                "start_ts": 1_700_000_000 + i * 900,
+                "tf_sec": 900,
+                "o": price - 0.2,
+                "h": price + 0.4,
+                "l": price - 0.5,
+                "c": price,
+            }
+        )
+
+    candles_path = tmp_path / "candles.jsonl"
+    candles_path.write_text(
+        "".join(json.dumps(candle, separators=(",", ":")) + "\n" for candle in candles),
+        encoding="utf-8",
+    )
+    return config_path, candles_path
+
+
+def test_replay_outputs_are_deterministic(monkeypatch, tmp_path: Path) -> None:
+    config_path, candles_path = _write_fixture_files(tmp_path)
+    monkeypatch.setenv("APB_CONFIG", str(config_path))
+
+    start_ts = 1_700_000_000 + 49 * 900
+    end_ts = 1_700_000_000 + 79 * 900
+
+    first = replay_fixed_window(
+        strategy_id="aggressive",
+        candles_file=candles_path,
+        pair="ETH/USD",
+        tf_min=15,
+        output_root=tmp_path / "out-a",
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+    second = replay_fixed_window(
+        strategy_id="aggressive",
+        candles_file=candles_path,
+        pair="ETH/USD",
+        tf_min=15,
+        output_root=tmp_path / "out-b",
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+
+    assert first.summary == second.summary
+    assert first.manifest == second.manifest
+    assert first.cycles == second.cycles
+    assert first.trades == second.trades
+    assert first.equity_curve == second.equity_curve
+
+    for name in ("manifest.json", "summary.json", "cycles.jsonl", "trades.jsonl", "equity.jsonl"):
+        assert (first.output_dir / name).read_text(encoding="utf-8") == (
+            second.output_dir / name
+        ).read_text(encoding="utf-8")
+
+    assert first.summary["trade_count"] == 4
+    assert first.summary["decision_counts"] == {"skip": 10, "trade": 5, "veto": 16}
+    assert any(row["decision"]["status"] == "veto" for row in first.cycles)
+    assert any(row["analysis"]["regime_label"] == "trend_up" for row in first.cycles)
+    assert any(trade["kind"] == "take_profit_partial" for trade in first.trades)
+
+
+def test_replay_comparison_uses_same_window(monkeypatch, tmp_path: Path) -> None:
+    config_path, candles_path = _write_fixture_files(tmp_path)
+    monkeypatch.setenv("APB_CONFIG", str(config_path))
+
+    start_ts = 1_700_000_000 + 49 * 900
+    end_ts = 1_700_000_000 + 79 * 900
+    output_root = tmp_path / "out"
+
+    baseline = replay_fixed_window(
+        strategy_id="conservative",
+        candles_file=candles_path,
+        pair="ETH/USD",
+        tf_min=15,
+        output_root=output_root,
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+    candidate = replay_fixed_window(
+        strategy_id="aggressive",
+        candles_file=candles_path,
+        pair="ETH/USD",
+        tf_min=15,
+        output_root=output_root,
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+    comparison_path = write_comparison(output_root, baseline, candidate)
+    comparison = json.loads(comparison_path.read_text(encoding="utf-8"))
+
+    assert baseline.summary["window"] == candidate.summary["window"] == comparison["window"]
+    assert comparison["baseline"]["strategy_id"] == "conservative"
+    assert comparison["candidate"]["strategy_id"] == "aggressive"
+    assert comparison["delta"]["trade_count"] == 4
+    assert comparison["baseline"]["summary"]["trade_count"] == 0
+    assert comparison["candidate"]["summary"]["trade_count"] == 4


### PR DESCRIPTION
## summary
- add a deterministic fixed-window replay harness over stored candle history
- emit stable machine-readable replay artifacts including regimes, setups, skips/vetoes, executions, and equity curve
- support same-window baseline vs candidate comparison output and document the first-slice contract

## validation
- `python3 -m compileall src tests`
- attempted `python3 -m pytest -q tests/test_replay.py tests/test_strategy_foundation.py` (pytest not installed in this shell)

Closes #35

## rollback note
Revert this PR to remove the replay harness, artifact contract additions, and comparison surface if the first-slice shape needs to be redesigned.