### PR TITLE
feat: add regime-first trend continuation strategy lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,15 @@ risk controls are explicit and should be treated as first-class change surfaces:
 - sizing bounds
 - confidence thresholds (`min_confidence_to_trade`)
 
-strategy behavior can be profile-driven (`strategy.profiles`), so aggressive mode can use
-higher deployment + lower confidence gates while conservative remains unchanged.
+strategy behavior is currently narrow by design:
+- only the regime-first `trend_continuation` lane is tradeable
+- `trend_up` entries are limited to `pullback_long` and `breakout_long`
+- `trend_down` entries are limited to `failed_bounce_short` and `breakdown_short`
+- range/transition windows stand down instead of opening a separate range lane
+- replay and live artifacts expose setup labels plus invalidation/exit reasons
+
+strategy behavior can still be profile-driven (`strategy.profiles`) for risk and classifier thresholds,
+while the lane taxonomy stays small and interpretable.
 
 `edge_filtered` is an additive paper experiment lane using a stricter confidence gate
 (`min_confidence_to_trade: 0.60`) to skip lower-conviction entries.

--- a/docs/ARTIFACT_CONTRACT_V1.md
+++ b/docs/ARTIFACT_CONTRACT_V1.md
@@ -22,17 +22,20 @@ Each decision artifact MUST include an `effective_config` object with compact de
 - `signal.trend_weight`, `signal.trend_weight_in_regime`, `signal.mr_weight`
 - `signal.adx_threshold`, `signal.regime_confidence_floor`
 - `signal.tie_break_to_trend`, `signal.tie_break_min_confidence`
+- `signal.trend_lane_min_confidence`, `signal.continuation_lookback`
 
 This object is intentionally compact: enough for forensic review to explain the effective thresholds in force without embedding the entire raw config blob.
 
 ## Canonical decision fields
 Each decision artifact MUST include a `decision` object with:
 - `regime`: machine-comparable regime label such as `trend_up`, `trend_down`, `range`, `transition`, `unknown`
-- `setup_type`: machine-comparable setup label such as `trend_follow_long`, `trend_follow_short`, `regime_tie_break`, `no_trade`
+- `setup_type`: machine-comparable setup label such as `pullback_long`, `breakout_long`, `failed_bounce_short`, `breakdown_short`, `no_trade`
+- `strategy_lane`: machine-comparable lane label such as `trend_continuation`, `stand_down`, `unknown`
 - `decision_status`: canonical outcome for the cycle
 - `decision_reason`: canonical positive-path reason code when the bot acts or intentionally holds a live position
 - `block_reason`: canonical negative-path reason code when the bot skips or vetoes
 - `exit_reason`: canonical exit reason code when the bot closes, flips, or is forced out
+- `invalidation_reason`: deterministic lane invalidation code when present
 
 ## `decision_status`
 Allowed values in this slice:
@@ -48,8 +51,8 @@ Allowed values in this slice:
 ## Reason codes
 Current reason codes emitted in this slice:
 - `decision_reason`: `entry_signal`, `add_signal`, `reverse_signal`, `existing_position`
-- `block_reason`: `no_market_data`, `signal_flat`, `no_setup`, `confidence_below_min`, `invalid_stop`, `risk_gate`
-- `exit_reason`: `signal_flat`, `reverse_signal`, `position_exit`, `stop_loss`
+- `block_reason`: `no_market_data`, `signal_flat`, `no_setup`, `confidence_below_min`, `invalid_stop`, `risk_gate`, `transition_stand_down`, `confidence_collapse`, `regime_not_confirmed`, `trend_structure_lost`
+- `exit_reason`: `signal_flat`, `reverse_signal`, `position_exit`, `stop_loss`, `transition_stand_down`, `confidence_collapse`, `regime_not_confirmed`, `trend_structure_lost`
 
 ## Notes vs canonical fields
 Human-readable notes remain available for debugging:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,22 +42,19 @@ This repo is a **paper-first** scaffold for trading **Avantis perps** (starting 
 ## What decides long vs short?
 
 ### Signals (`src/bot/strategies.py`)
-`choose_signal(closes)` combines two deterministic strategies:
+`choose_signal(candles)` currently exposes one tradeable lane: `trend_continuation`.
 
-- **Trend (default bias)**
-  - fast/slow SMA cross (20 vs 50)
-  - plus a crude slope proxy (fast SMA delta over 3 bars)
-  - Long when: `fast > slow` AND `slope > 0`
-  - Short when: `fast < slow` AND `slope < 0`
+- The regime classifier must first confirm `trend_up` or `trend_down`
+- Outside confirmed trend regimes, the strategy stands down
+- `trend_up` entries:
+  - `pullback_long`: oversold pullback inside a confirmed uptrend
+  - `breakout_long`: close breaks above the recent continuation lookback window
+- `trend_down` entries:
+  - `failed_bounce_short`: overbought bounce inside a confirmed downtrend
+  - `breakdown_short`: close breaks below the recent continuation lookback window
+- Counter-trend entries are blocked while the lane is active
 
-- **Mean reversion**
-  - z-score of close vs SMA window (50)
-  - Long when: `z <= -1.5` (oversold)
-  - Short when: `z >= +1.5` (overbought)
-
-Resolver:
-- if both agree (non-flat), take that direction
-- else prefer the one with higher confidence
+Mean reversion is still used as an interpretable feature for regime/setup detection, but not as a standalone counter-trend entry lane in this slice.
 
 ### Regime classifier (`src/bot/strategies.py`)
 `classify_regime(candles)` produces one deterministic object with schema version `regime_classifier.v1`:
@@ -85,6 +82,16 @@ Resolver:
   - 0.84–0.92 → 4x
   - ≥0.92 → 5x
   - plus strategy-specific cap: mean reversion max 3x
+
+### Position management
+- No position: open only on one of the explicit continuation setups above
+- Existing aligned position: hold through non-entry candles while the trend lane remains valid
+- Existing position stand-down / close triggers:
+  - `transition_stand_down`
+  - `confidence_collapse`
+  - `regime_not_confirmed`
+  - `trend_structure_lost`
+- On invalidation, the engine closes and stands down rather than flipping directly into the opposite side on the same cycle
 
 ### Paper execution (`src/bot/paper_engine.py`)
 - Single position at a time

--- a/docs/strategy/STRATEGY_CONTRACT_V1.md
+++ b/docs/strategy/STRATEGY_CONTRACT_V1.md
@@ -9,6 +9,26 @@
 ## objective
 Define auditable strategy-lane behavior and profile configuration for `conservative` and `aggressive` modes.
 
+## active directional lane
+The current tradeable lane is `trend_continuation`.
+
+- trade only when the regime classifier confirms `trend_up` or `trend_down`
+- `trend_up`: entries are restricted to `pullback_long` or `breakout_long`
+- `trend_down`: entries are restricted to `failed_bounce_short` or `breakdown_short`
+- `range` and `transition` do not have a trade lane in this slice; runtime MUST stand down
+- once the trend lane is active, counter-trend entries are not allowed
+- open positions may be held between entry candles, but MUST stand down and close on deterministic invalidation
+
+## deterministic invalidation / stand-down
+- `transition_stand_down`: classifier marks the window uncertain or transitional
+- `confidence_collapse`: regime confidence falls below the trend-lane minimum
+- `regime_not_confirmed`: classifier is not in a confirmed trend regime
+- `trend_structure_lost`: fast/slow trend structure no longer points in the regime direction
+
+When one of these reasons is active:
+- no new entry may be opened
+- an existing position in the lane MUST close rather than flip directly into the opposite side
+
 ## strategy ids and fallback
 - allowed ids come from `strategy.allowed_ids`
 - default id comes from `strategy.default_id`
@@ -24,6 +44,8 @@ Define auditable strategy-lane behavior and profile configuration for `conservat
 - `tie_break_to_trend`
 - `tie_break_min_confidence`
 - `regime_confidence_floor`
+- `trend_lane_min_confidence`
+- `continuation_lookback`
 
 If a field is omitted in profile, runtime MUST use global base risk/signal defaults.
 
@@ -43,11 +65,14 @@ Profile tuning MUST NOT bypass these invariants:
 | `adx_threshold` | controls regime activation sensitivity |
 | `tie_break_to_trend` | resolves tie/noise toward trend direction in regime |
 | `regime_confidence_floor` | minimum confidence in confirmed regime decisions |
+| `trend_lane_min_confidence` | minimum classifier confidence required before the continuation lane may trade |
+| `continuation_lookback` | breakout/breakdown lookback used by continuation setups |
 
 ## required journaling fields
 Each cycle/trade artifact MUST include:
 - `strategy_id`
 - `regime_classifier`: schema_version, label, confidence, probabilities, stand_down, uncertainty_score
+- `analysis.setup_label`, `analysis.strategy_lane`, `analysis.invalidation_reason`
 - signal: desired/confidence/strategy/note
 - plan: action, leverage, risk_usd, stop/take fields
 - state: equity, daily_pnl, position, last_price

--- a/src/bot/artifacts.py
+++ b/src/bot/artifacts.py
@@ -62,6 +62,8 @@ def build_effective_config(*, effective_risk: Any, signal_cfg: Any) -> dict[str,
             "regime_confidence_floor": signal.get("regime_confidence_floor"),
             "tie_break_to_trend": signal.get("tie_break_to_trend"),
             "tie_break_min_confidence": signal.get("tie_break_min_confidence"),
+            "trend_lane_min_confidence": signal.get("trend_lane_min_confidence"),
+            "continuation_lookback": signal.get("continuation_lookback"),
         },
     }
 
@@ -78,8 +80,10 @@ def build_decision_artifact(
     regime = "unknown"
     regime_note = None
     setup_type = "no_trade"
+    strategy_lane = "unknown"
     signal_desired = "flat"
     signal_note = None
+    invalidation_reason = None
     plan_action = None
     plan_note = None
 
@@ -87,8 +91,10 @@ def build_decision_artifact(
         regime = analysis.regime_label
         regime_note = analysis.regime_note
         setup_type = analysis.setup_label
+        strategy_lane = analysis.strategy_lane
         signal_desired = analysis.signal.desired
         signal_note = analysis.signal.note
+        invalidation_reason = analysis.invalidation_reason
 
     if plan is not None:
         plan_action = plan.action
@@ -117,12 +123,12 @@ def build_decision_artifact(
         exit_reason = "reverse_signal"
     elif plan.action == "close":
         decision_status = "close"
-        exit_reason = _close_exit_reason(signal_desired)
+        exit_reason = invalidation_reason or _close_exit_reason(signal_desired)
     elif previous_position is not None:
         decision_status = "hold"
         decision_reason = "existing_position"
     elif signal_desired == "flat":
-        block_reason = _skip_reason(setup_type, signal_note)
+        block_reason = invalidation_reason or _skip_reason(setup_type, signal_note)
     elif setup_type == "no_trade":
         block_reason = "no_setup"
     else:
@@ -134,10 +140,12 @@ def build_decision_artifact(
         "artifact_contract_version": ARTIFACT_CONTRACT_VERSION,
         "regime": regime,
         "setup_type": setup_type,
+        "strategy_lane": strategy_lane,
         "decision_status": decision_status,
         "decision_reason": decision_reason,
         "block_reason": block_reason,
         "exit_reason": exit_reason,
+        "invalidation_reason": invalidation_reason,
         "signal_desired": signal_desired,
         "plan_action": plan_action,
         "status": decision_status,

--- a/src/bot/config.py
+++ b/src/bot/config.py
@@ -51,6 +51,8 @@ class StrategyProfileConfig:
     tie_break_to_trend: bool = False
     tie_break_min_confidence: float = 0.0
     regime_confidence_floor: float = 0.0
+    trend_lane_min_confidence: float | None = None
+    continuation_lookback: int | None = None
 
 
 @dataclass
@@ -126,6 +128,12 @@ def load_config() -> BotConfig:
             tie_break_to_trend=bool(raw.get("tie_break_to_trend", False)),
             tie_break_min_confidence=float(raw.get("tie_break_min_confidence", 0.0)),
             regime_confidence_floor=float(raw.get("regime_confidence_floor", 0.0)),
+            trend_lane_min_confidence=(
+                None if raw.get("trend_lane_min_confidence") is None else float(raw.get("trend_lane_min_confidence"))
+            ),
+            continuation_lookback=(
+                None if raw.get("continuation_lookback") is None else int(raw.get("continuation_lookback"))
+            ),
         )
 
     cfg.strategy = StrategyConfig(default_id=default_id, allowed_ids=allowed_ids, profiles=profiles)

--- a/src/bot/replay.py
+++ b/src/bot/replay.py
@@ -19,7 +19,7 @@ from .paper_engine import execute_paper_with_events
 from .risk import compute_risk_budget, plan_from_signal
 from .runtime import default_paper_state, effective_risk_cfg, effective_signal_cfg, paper_state_from_raw
 from .storage import candles_path
-from .strategies import analyze_signal
+from .strategies import analyze_signal, apply_position_management
 from .utils import data_dir, jsonl_write, write_json_stable
 
 
@@ -179,20 +179,8 @@ def replay_fixed_window(
             rb=rb,
             cfg=effective_risk,
         )
-
         previous_position = None if state.position is None else asdict(state.position)
-        if state.position is not None:
-            if analysis.signal.desired == "flat":
-                plan.action = "close"
-                plan.side = state.position.side
-            else:
-                desired_side = "long" if analysis.signal.desired == "long" else "short"
-                if desired_side != state.position.side:
-                    plan.action = "flip"
-                    plan.side = desired_side
-                else:
-                    plan.action = "hold"
-                    plan.side = desired_side
+        plan = apply_position_management(plan, analysis, None if state.position is None else state.position.side)
 
         state, execution_events = execute_paper_with_events(
             state,
@@ -237,6 +225,8 @@ def replay_fixed_window(
                     "regime_label": analysis.regime_label,
                     "regime_note": analysis.regime_note,
                     "setup_label": analysis.setup_label,
+                    "strategy_lane": analysis.strategy_lane,
+                    "invalidation_reason": analysis.invalidation_reason,
                     "trend_signal": as_dict(analysis.trend_signal),
                     "mean_reversion_signal": as_dict(analysis.mean_reversion_signal),
                 },

--- a/src/bot/run_cycle.py
+++ b/src/bot/run_cycle.py
@@ -17,7 +17,7 @@ from .config import DEFAULT_STRATEGY_ID, as_dict, load_config
 from .paper_engine import execute_paper_with_events
 from .risk import compute_risk_budget, plan_from_signal
 from .runtime import default_paper_state, effective_risk_cfg, effective_signal_cfg, paper_state_from_raw
-from .strategies import analyze_signal
+from .strategies import analyze_signal, apply_position_management
 from .storage import candles_path, journal_path, snapshot_path, state_path
 from .utils import jsonl_append, read_json, write_json
 
@@ -97,22 +97,7 @@ def main() -> None:
         action_note = "no candles yet"
     else:
         plan = plan_from_signal(signal=sig, candles=candles, last_price=last_price, rb=rb, cfg=effective_risk)
-        # If we already have a position, upgrade open->scale/hold/flip/close based on direction.
-        if paper.position is None:
-            pass
-        else:
-            if sig.desired == "flat":
-                plan.action = "close"
-                plan.side = paper.position.side
-            else:
-                desired_side = "long" if sig.desired == "long" else "short"
-                if desired_side != paper.position.side:
-                    plan.action = "flip"
-                    plan.side = desired_side
-                else:
-                    # for now: hold (later AI can decide scale)
-                    plan.action = "hold"
-                    plan.side = desired_side
+        plan = apply_position_management(plan, analysis, None if paper.position is None else paper.position.side)
 
         action_note = plan.note if plan else "no-plan"
     execution_events: list[dict[str, Any]] = []
@@ -170,6 +155,8 @@ def main() -> None:
                     "regime_label": analysis.regime_label,
                     "regime_note": analysis.regime_note,
                     "setup_label": analysis.setup_label,
+                    "strategy_lane": analysis.strategy_lane,
+                    "invalidation_reason": analysis.invalidation_reason,
                     "trend_signal": as_dict(analysis.trend_signal),
                     "mean_reversion_signal": as_dict(analysis.mean_reversion_signal),
                 }
@@ -205,6 +192,8 @@ def main() -> None:
                 "regime_label": analysis.regime_label,
                 "regime_note": analysis.regime_note,
                 "setup_label": analysis.setup_label,
+                "strategy_lane": analysis.strategy_lane,
+                "invalidation_reason": analysis.invalidation_reason,
                 "trend_signal": as_dict(analysis.trend_signal),
                 "mean_reversion_signal": as_dict(analysis.mean_reversion_signal),
             }

--- a/src/bot/runtime.py
+++ b/src/bot/runtime.py
@@ -38,6 +38,10 @@ def effective_signal_cfg(cfg, strategy_id: str) -> SignalStrategyConfig:
     scfg.tie_break_to_trend = p.tie_break_to_trend
     scfg.tie_break_min_confidence = p.tie_break_min_confidence
     scfg.regime_confidence_floor = p.regime_confidence_floor
+    if p.trend_lane_min_confidence is not None:
+        scfg.trend_lane_min_confidence = p.trend_lane_min_confidence
+    if p.continuation_lookback is not None:
+        scfg.continuation_lookback = p.continuation_lookback
     return scfg
 
 

--- a/src/bot/strategies.py
+++ b/src/bot/strategies.py
@@ -1,9 +1,9 @@
 """Deterministic strategies (v0.2).
 
-Adds a weighted blend with trend-day regime detection:
-- Trend signal (fast/slow SMA + slope)
-- Mean-reversion signal (z-score)
-- Regime gate combines MA-structure + ADX strength
+Tradeable path in this slice:
+- one regime-first trend continuation lane
+- explicit continuation setups only in confirmed trend regimes
+- deterministic stand-down outside confirmed trend regimes
 """
 
 from __future__ import annotations
@@ -22,19 +22,17 @@ class StrategyConfig:
     trend_slow: int = 50
     mr_window: int = 50
     mr_entry_z: float = 1.5
-
-    # Weighted blend behavior
     trend_weight: float = 1.0
     mr_weight: float = 1.0
-    trend_weight_in_regime: float = 1.35  # medium priority
+    trend_weight_in_regime: float = 1.35
 
     # Combined trend-day regime filter
     adx_n: int = 14
     adx_threshold: float = 20.0
     min_spread_ratio: float = 0.0015  # |fast-slow|/slow
     min_slope_ratio: float = 0.0008
-
-    # Aggressive-mode knobs
+    trend_lane_min_confidence: float = 0.55
+    continuation_lookback: int = 5
     tie_break_to_trend: bool = False
     tie_break_min_confidence: float = 0.0
     regime_confidence_floor: float = 0.0
@@ -47,6 +45,8 @@ class SignalAnalysis:
     mean_reversion_signal: Signal
     regime: RegimeClassifierOutput
     setup_label: str
+    strategy_lane: str
+    invalidation_reason: str | None = None
 
     @property
     def regime_label(self) -> str:
@@ -278,6 +278,75 @@ def classify_regime(candles: list[dict], cfg: StrategyConfig | None = None) -> R
     )
 
 
+def _continuation_breakout(closes: list[float], lookback: int, side: str) -> bool:
+    if len(closes) <= lookback:
+        return False
+
+    window = closes[-(lookback + 1) : -1]
+    current = closes[-1]
+    if side == "long":
+        return current > max(window)
+    return current < min(window)
+
+
+def _trend_lane_state(
+    closes: list[float],
+    trend: Signal,
+    mean_reversion: Signal,
+    regime: RegimeClassifierOutput,
+    cfg: StrategyConfig,
+) -> tuple[str, Signal, str, str | None]:
+    lane_off = Signal(desired="flat", confidence=0.0, strategy="trend_continuation", note="stand_down")
+
+    if regime.stand_down:
+        return "stand_down", Signal(desired="flat", confidence=0.0, strategy="trend_continuation", note="transition stand_down"), "no_trade", "transition_stand_down"
+    if regime.confidence < cfg.trend_lane_min_confidence:
+        return "stand_down", Signal(desired="flat", confidence=0.0, strategy="trend_continuation", note="regime confidence collapse"), "no_trade", "confidence_collapse"
+    if regime.label not in {MarketRegime.TREND_UP, MarketRegime.TREND_DOWN}:
+        return "stand_down", lane_off, "no_trade", "regime_not_confirmed"
+
+    if regime.label is MarketRegime.TREND_UP:
+        if trend.desired != "long":
+            return "trend_continuation", Signal(desired="flat", confidence=0.0, strategy="trend_continuation", note="trend structure lost"), "no_trade", "trend_structure_lost"
+        if mean_reversion.desired == "long":
+            conf = max(regime.confidence, trend.confidence)
+            return (
+                "trend_continuation",
+                Signal(desired="long", confidence=round(min(1.0, conf), 6), strategy="trend_continuation", note="trend_up pullback_long"),
+                "pullback_long",
+                None,
+            )
+        if _continuation_breakout(closes, cfg.continuation_lookback, "long"):
+            conf = max(regime.confidence, trend.confidence)
+            return (
+                "trend_continuation",
+                Signal(desired="long", confidence=round(min(1.0, conf), 6), strategy="trend_continuation", note="trend_up breakout_long"),
+                "breakout_long",
+                None,
+            )
+        return "trend_continuation", Signal(desired="flat", confidence=0.0, strategy="trend_continuation", note="trend_up waiting for continuation setup"), "no_trade", None
+
+    if trend.desired != "short":
+        return "trend_continuation", Signal(desired="flat", confidence=0.0, strategy="trend_continuation", note="trend structure lost"), "no_trade", "trend_structure_lost"
+    if mean_reversion.desired == "short":
+        conf = max(regime.confidence, trend.confidence)
+        return (
+            "trend_continuation",
+            Signal(desired="short", confidence=round(min(1.0, conf), 6), strategy="trend_continuation", note="trend_down failed_bounce_short"),
+            "failed_bounce_short",
+            None,
+        )
+    if _continuation_breakout(closes, cfg.continuation_lookback, "short"):
+        conf = max(regime.confidence, trend.confidence)
+        return (
+            "trend_continuation",
+            Signal(desired="short", confidence=round(min(1.0, conf), 6), strategy="trend_continuation", note="trend_down breakdown_short"),
+            "breakdown_short",
+            None,
+        )
+    return "trend_continuation", Signal(desired="flat", confidence=0.0, strategy="trend_continuation", note="trend_down waiting for continuation setup"), "no_trade", None
+
+
 def analyze_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> SignalAnalysis:
     cfg = cfg or StrategyConfig()
     closes = [float(c["c"]) for c in candles if "c" in c]
@@ -296,104 +365,52 @@ def analyze_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> Si
             ),
             regime=regime,
             setup_label="no_trade",
+            strategy_lane="stand_down",
+            invalidation_reason="no_market_data",
         )
 
     t = trend_signal(closes, cfg)
     m = mean_reversion_signal(closes, cfg)
     regime = classify_regime(candles, cfg)
-
-    regime_on = regime.label in {MarketRegime.TREND_UP, MarketRegime.TREND_DOWN}
-    tw = cfg.trend_weight_in_regime if regime_on else cfg.trend_weight
-    mw = cfg.mr_weight
-
-    long_score = 0.0
-    short_score = 0.0
-    setup_label = "no_trade"
-
-    if t.desired == "long":
-        long_score += t.confidence * tw
-    elif t.desired == "short":
-        short_score += t.confidence * tw
-
-    if m.desired == "long":
-        long_score += m.confidence * mw
-    elif m.desired == "short":
-        short_score += m.confidence * mw
-
-    if long_score <= 0 and short_score <= 0:
-        signal = Signal(desired="flat", confidence=0.35, strategy="combo", note=f"both flat | {regime.note}")
-        return SignalAnalysis(
-            signal=signal,
-            trend_signal=t,
-            mean_reversion_signal=m,
-            regime=regime,
-            setup_label=setup_label,
-        )
-
-    if long_score > short_score + 0.05:
-        conf = min(1.0, long_score / (tw + mw))
-        if regime_on and cfg.regime_confidence_floor > 0:
-            conf = max(conf, cfg.regime_confidence_floor)
-        if t.desired == "long" and m.desired == "long":
-            setup_label = "trend_plus_mean_reversion_long"
-        elif t.desired == "long":
-            setup_label = "trend_follow_long"
-        elif m.desired == "long":
-            setup_label = "mean_reversion_long"
-        signal = Signal(desired="long", confidence=conf, strategy="combo", note=f"weighted long ({regime.note})")
-        return SignalAnalysis(
-            signal=signal,
-            trend_signal=t,
-            mean_reversion_signal=m,
-            regime=regime,
-            setup_label=setup_label,
-        )
-
-    if short_score > long_score + 0.05:
-        conf = min(1.0, short_score / (tw + mw))
-        if regime_on and cfg.regime_confidence_floor > 0:
-            conf = max(conf, cfg.regime_confidence_floor)
-        if t.desired == "short" and m.desired == "short":
-            setup_label = "trend_plus_mean_reversion_short"
-        elif t.desired == "short":
-            setup_label = "trend_follow_short"
-        elif m.desired == "short":
-            setup_label = "mean_reversion_short"
-        signal = Signal(desired="short", confidence=conf, strategy="combo", note=f"weighted short ({regime.note})")
-        return SignalAnalysis(
-            signal=signal,
-            trend_signal=t,
-            mean_reversion_signal=m,
-            regime=regime,
-            setup_label=setup_label,
-        )
-
-    # tie/noisy area
-    if regime_on and cfg.tie_break_to_trend and t.desired in {"long", "short"} and t.confidence >= cfg.tie_break_min_confidence:
-        conf = max(t.confidence, cfg.regime_confidence_floor)
-        signal = Signal(
-            desired=t.desired,
-            confidence=min(1.0, conf),
-            strategy="combo",
-            note=f"regime tie-break via trend ({regime.note})",
-        )
-        return SignalAnalysis(
-            signal=signal,
-            trend_signal=t,
-            mean_reversion_signal=m,
-            regime=regime,
-            setup_label="regime_tie_break",
-        )
-
-    signal = Signal(desired="flat", confidence=0.4, strategy="combo", note=f"tie/noise ({regime.note})")
+    strategy_lane, signal, setup_label, invalidation_reason = _trend_lane_state(closes, t, m, regime, cfg)
     return SignalAnalysis(
         signal=signal,
         trend_signal=t,
         mean_reversion_signal=m,
         regime=regime,
         setup_label=setup_label,
+        strategy_lane=strategy_lane,
+        invalidation_reason=invalidation_reason,
     )
 
 
 def choose_signal(candles: list[dict], cfg: StrategyConfig | None = None) -> Signal:
     return analyze_signal(candles, cfg).signal
+
+
+def apply_position_management(plan, analysis: SignalAnalysis | None, current_side: str | None):
+    if plan is None or analysis is None or current_side is None:
+        return plan
+
+    if analysis.invalidation_reason is not None:
+        plan.action = "close"
+        plan.side = current_side
+        plan.note = f"close: {analysis.invalidation_reason}"
+        return plan
+
+    if analysis.signal.desired == "flat":
+        plan.action = "hold"
+        plan.side = current_side
+        plan.note = "hold: active trend lane waiting for continuation setup"
+        return plan
+
+    desired_side = "long" if analysis.signal.desired == "long" else "short"
+    if desired_side != current_side:
+        plan.action = "close"
+        plan.side = current_side
+        plan.note = "close: regime_change_stand_down"
+        return plan
+
+    plan.action = "hold"
+    plan.side = current_side
+    return plan

--- a/tests/test_decision_artifacts.py
+++ b/tests/test_decision_artifacts.py
@@ -18,10 +18,12 @@ def _analysis(
     *,
     desired: str = "long",
     regime: str = "trend_up",
-    setup: str = "trend_follow_long",
-    note: str = "weighted long",
+    setup: str = "breakout_long",
+    note: str = "trend_up breakout_long",
+    strategy_lane: str = "trend_continuation",
+    invalidation_reason: str | None = None,
 ) -> SignalAnalysis:
-    signal = Signal(desired=desired, confidence=0.8, strategy="combo", note=note)
+    signal = Signal(desired=desired, confidence=0.8, strategy="trend_continuation", note=note)
     return SignalAnalysis(
         signal=signal,
         trend_signal=Signal(desired=desired, confidence=0.8, strategy="trend", note="trend"),
@@ -51,6 +53,8 @@ def _analysis(
             },
         ),
         setup_label=setup,
+        strategy_lane=strategy_lane,
+        invalidation_reason=invalidation_reason,
     )
 
 
@@ -87,6 +91,8 @@ def test_effective_config_is_compact_and_stable() -> None:
             regime_confidence_floor=0.28,
             tie_break_to_trend=True,
             tie_break_min_confidence=0.55,
+            trend_lane_min_confidence=0.55,
+            continuation_lookback=5,
         ),
     )
 
@@ -102,10 +108,12 @@ def test_effective_config_is_compact_and_stable() -> None:
   },
   \"signal\": {
     \"adx_threshold\": 16.0,
+    \"continuation_lookback\": 5,
     \"mr_weight\": 0.8,
     \"regime_confidence_floor\": 0.28,
     \"tie_break_min_confidence\": 0.55,
     \"tie_break_to_trend\": true,
+    \"trend_lane_min_confidence\": 0.55,
     \"trend_weight\": 1.0,
     \"trend_weight_in_regime\": 1.8
   }
@@ -132,7 +140,14 @@ def test_decision_contract_serialization_is_stable() -> None:
             previous_position={"side": "long"},
         ),
         "close": build_decision_artifact(
-            analysis=_analysis(desired="flat", regime="transition", setup="no_trade", note="both flat"),
+            analysis=_analysis(
+                desired="flat",
+                regime="transition",
+                setup="no_trade",
+                note="transition stand_down",
+                strategy_lane="stand_down",
+                invalidation_reason="transition_stand_down",
+            ),
             plan=_plan("close"),
             previous_position={"side": "long"},
         ),
@@ -150,16 +165,18 @@ def test_decision_contract_serialization_is_stable() -> None:
     "block_reason": null,
     "decision_reason": null,
     "decision_status": "close",
-    "exit_reason": "signal_flat",
+    "exit_reason": "transition_stand_down",
+    "invalidation_reason": "transition_stand_down",
     "plan_action": "close",
     "plan_note": "combo conf=0.80",
-    "reason": "signal_flat",
+    "reason": "transition_stand_down",
     "regime": "transition",
     "regime_note": "adx=25.0 spread=0.0100 slope=0.0050",
     "setup_type": "no_trade",
     "signal_desired": "flat",
-    "signal_note": "both flat",
-    "status": "close"
+    "signal_note": "transition stand_down",
+    "status": "close",
+    "strategy_lane": "stand_down"
   },
   "forced_exit": {
     "artifact_contract_version": "decision_artifact.v1",
@@ -167,15 +184,17 @@ def test_decision_contract_serialization_is_stable() -> None:
     "decision_reason": null,
     "decision_status": "forced_exit",
     "exit_reason": "stop_loss",
+    "invalidation_reason": null,
     "plan_action": "hold",
     "plan_note": "combo conf=0.80",
     "reason": "stop_loss",
     "regime": "trend_up",
     "regime_note": "adx=25.0 spread=0.0100 slope=0.0050",
-    "setup_type": "trend_follow_long",
+    "setup_type": "breakout_long",
     "signal_desired": "long",
-    "signal_note": "weighted long",
-    "status": "forced_exit"
+    "signal_note": "trend_up breakout_long",
+    "status": "forced_exit",
+    "strategy_lane": "trend_continuation"
   },
   "hold": {
     "artifact_contract_version": "decision_artifact.v1",
@@ -183,15 +202,17 @@ def test_decision_contract_serialization_is_stable() -> None:
     "decision_reason": "existing_position",
     "decision_status": "hold",
     "exit_reason": null,
+    "invalidation_reason": null,
     "plan_action": "hold",
     "plan_note": "combo conf=0.80",
     "reason": "existing_position",
     "regime": "trend_up",
     "regime_note": "adx=25.0 spread=0.0100 slope=0.0050",
-    "setup_type": "trend_follow_long",
+    "setup_type": "breakout_long",
     "signal_desired": "long",
-    "signal_note": "weighted long",
-    "status": "hold"
+    "signal_note": "trend_up breakout_long",
+    "status": "hold",
+    "strategy_lane": "trend_continuation"
   },
   "skip": {
     "artifact_contract_version": "decision_artifact.v1",
@@ -199,6 +220,7 @@ def test_decision_contract_serialization_is_stable() -> None:
     "decision_reason": null,
     "decision_status": "skip",
     "exit_reason": null,
+    "invalidation_reason": null,
     "plan_action": null,
     "plan_note": null,
     "reason": "no_market_data",
@@ -207,7 +229,8 @@ def test_decision_contract_serialization_is_stable() -> None:
     "setup_type": "no_trade",
     "signal_desired": "flat",
     "signal_note": null,
-    "status": "skip"
+    "status": "skip",
+    "strategy_lane": "unknown"
   },
   "veto": {
     "artifact_contract_version": "decision_artifact.v1",
@@ -215,15 +238,17 @@ def test_decision_contract_serialization_is_stable() -> None:
     "decision_reason": null,
     "decision_status": "veto",
     "exit_reason": null,
+    "invalidation_reason": null,
     "plan_action": "hold",
     "plan_note": "skip: conf=0.55 below threshold=0.60 (combo)",
     "reason": "confidence_below_min",
     "regime": "trend_up",
     "regime_note": "adx=25.0 spread=0.0100 slope=0.0050",
-    "setup_type": "trend_follow_long",
+    "setup_type": "breakout_long",
     "signal_desired": "long",
-    "signal_note": "weighted long",
-    "status": "veto"
+    "signal_note": "trend_up breakout_long",
+    "status": "veto",
+    "strategy_lane": "trend_continuation"
   }
 }
 """
@@ -318,5 +343,7 @@ def test_run_cycle_writes_contract_to_journal_and_snapshot(monkeypatch, tmp_path
     assert journal_payload["effective_config"]["risk"]["min_confidence_to_trade"] == 0.6
     assert snapshot["artifact_contract_version"] == ARTIFACT_CONTRACT_VERSION
     assert snapshot["decision"]["decision_status"] == "hold"
-    assert snapshot["decision"]["setup_type"] == "trend_follow_long"
+    assert snapshot["decision"]["setup_type"] == "breakout_long"
+    assert snapshot["decision"]["strategy_lane"] == "trend_continuation"
+    assert snapshot["analysis"]["invalidation_reason"] is None
     assert snapshot["effective_config"]["signal"]["trend_weight_in_regime"] is not None

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -135,7 +135,7 @@ def test_replay_comparison_uses_same_window(monkeypatch, tmp_path: Path) -> None
     assert baseline.summary["window"] == candidate.summary["window"] == comparison["window"]
     assert comparison["baseline"]["strategy_id"] == "conservative"
     assert comparison["candidate"]["strategy_id"] == "aggressive"
-    assert comparison["delta"]["trade_count"] == 2
-    assert comparison["baseline"]["summary"]["trade_count"] == 0
+    assert comparison["delta"]["trade_count"] == 0
+    assert comparison["baseline"]["summary"]["trade_count"] == 2
     assert comparison["candidate"]["summary"]["trade_count"] == 2
     assert comparison["candidate"]["summary"]["artifact_contract_version"] == "decision_artifact.v1"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -87,12 +87,14 @@ def test_replay_outputs_are_deterministic(monkeypatch, tmp_path: Path) -> None:
             second.output_dir / name
         ).read_text(encoding="utf-8")
 
-    assert first.summary["trade_count"] == 3
-    assert first.summary["decision_counts"] == {"forced_exit": 2, "hold": 14, "open": 3, "skip": 11, "veto": 1}
+    assert first.summary["trade_count"] == 2
+    assert first.summary["decision_counts"] == {"forced_exit": 1, "hold": 12, "open": 2, "skip": 16}
     assert first.summary["provenance"]["strategy_id"] == "aggressive"
     assert first.summary["effective_config"]["risk"]["min_confidence_to_trade"] == 0.6
     assert any(row["decision"]["decision_status"] == "forced_exit" for row in first.cycles)
     assert any(row["decision"]["decision_status"] == "hold" for row in first.cycles)
+    assert any(row["decision"]["strategy_lane"] == "trend_continuation" for row in first.cycles)
+    assert any(row["analysis"]["invalidation_reason"] == "transition_stand_down" for row in first.cycles)
     assert all(row["provenance"]["strategy_fingerprint"] == first.fingerprint for row in first.cycles)
     assert all(row["effective_config"]["signal"]["adx_threshold"] is not None for row in first.cycles)
     assert any(row["analysis"]["regime_label"] == "trend_up" for row in first.cycles)
@@ -133,7 +135,7 @@ def test_replay_comparison_uses_same_window(monkeypatch, tmp_path: Path) -> None
     assert baseline.summary["window"] == candidate.summary["window"] == comparison["window"]
     assert comparison["baseline"]["strategy_id"] == "conservative"
     assert comparison["candidate"]["strategy_id"] == "aggressive"
-    assert comparison["delta"]["trade_count"] == 3
+    assert comparison["delta"]["trade_count"] == 2
     assert comparison["baseline"]["summary"]["trade_count"] == 0
-    assert comparison["candidate"]["summary"]["trade_count"] == 3
+    assert comparison["candidate"]["summary"]["trade_count"] == 2
     assert comparison["candidate"]["summary"]["artifact_contract_version"] == "decision_artifact.v1"

--- a/tests/test_trend_continuation_lane.py
+++ b/tests/test_trend_continuation_lane.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from bot.strategies import StrategyConfig, analyze_signal, apply_position_management
+from bot.models import OrderPlan
+
+
+def _candles_from_closes(closes: list[float], *, tf_sec: int = 900) -> list[dict]:
+    return [
+        {
+            "start_ts": 1_700_200_000 + idx * tf_sec,
+            "tf_sec": tf_sec,
+            "o": close - 0.4,
+            "h": close + 0.8,
+            "l": close - 0.8,
+            "c": close,
+        }
+        for idx, close in enumerate(closes)
+    ]
+
+
+def _plan(side: str | None = "long") -> OrderPlan:
+    return OrderPlan(
+        action="open",
+        side=side,
+        target_notional_usd=50.0,
+        collateral_usd=25.0,
+        leverage=2.0,
+        stop_loss=95.0,
+        take_profit=110.0,
+        risk_usd=10.0,
+        note="trend lane",
+    )
+
+
+def test_trend_lane_opens_breakout_long_in_confirmed_uptrend() -> None:
+    closes = [100.0 + i * 1.0 for i in range(75)] + [174.2, 175.3, 176.5, 177.8, 179.4]
+
+    analysis = analyze_signal(_candles_from_closes(closes))
+
+    assert analysis.strategy_lane == "trend_continuation"
+    assert analysis.regime_label == "trend_up"
+    assert analysis.signal.desired == "long"
+    assert analysis.setup_label == "breakout_long"
+    assert analysis.invalidation_reason is None
+
+
+def test_trend_lane_opens_breakdown_short_in_confirmed_downtrend() -> None:
+    closes = [200.0 - i * 1.0 for i in range(75)] + [125.8, 124.9, 123.7, 122.5, 121.0]
+
+    analysis = analyze_signal(_candles_from_closes(closes))
+
+    assert analysis.strategy_lane == "trend_continuation"
+    assert analysis.regime_label == "trend_down"
+    assert analysis.signal.desired == "short"
+    assert analysis.setup_label == "breakdown_short"
+    assert analysis.invalidation_reason is None
+
+
+def test_trend_lane_stands_down_in_chop() -> None:
+    closes = [100.0 + ((i % 4) - 1.5) * 0.55 for i in range(80)]
+
+    analysis = analyze_signal(_candles_from_closes(closes))
+
+    assert analysis.signal.desired == "flat"
+    assert analysis.setup_label == "no_trade"
+    assert analysis.strategy_lane == "stand_down"
+    assert analysis.invalidation_reason in {"transition_stand_down", "regime_not_confirmed", "confidence_collapse"}
+
+
+def test_trend_lane_never_takes_countertrend_signal_in_confirmed_uptrend() -> None:
+    cfg = StrategyConfig(mr_window=10, mr_entry_z=1.0)
+    closes = [100.0 + i * 0.9 for i in range(75)] + [168.0, 170.0, 172.0, 176.0, 181.0]
+
+    analysis = analyze_signal(_candles_from_closes(closes), cfg)
+
+    assert analysis.regime_label == "trend_up"
+    assert analysis.signal.desired != "short"
+    assert analysis.setup_label in {"breakout_long", "no_trade"}
+
+
+def test_trend_lane_never_takes_countertrend_signal_in_confirmed_downtrend() -> None:
+    cfg = StrategyConfig(mr_window=10, mr_entry_z=1.0)
+    closes = [200.0 - i * 0.9 for i in range(75)] + [132.0, 130.0, 128.0, 124.0, 119.0]
+
+    analysis = analyze_signal(_candles_from_closes(closes), cfg)
+
+    assert analysis.regime_label == "trend_down"
+    assert analysis.signal.desired != "long"
+    assert analysis.setup_label in {"breakdown_short", "no_trade"}
+
+
+def test_position_management_holds_without_fresh_setup_but_closes_on_invalidation() -> None:
+    hold_analysis = analyze_signal(_candles_from_closes([100.0 + i * 1.0 for i in range(80)]))
+    hold_analysis.signal.desired = "flat"
+    hold_analysis.setup_label = "no_trade"
+    hold_analysis.invalidation_reason = None
+
+    hold_plan = apply_position_management(_plan("long"), hold_analysis, "long")
+
+    assert hold_plan.action == "hold"
+    assert hold_plan.side == "long"
+
+    close_analysis = analyze_signal(_candles_from_closes([100.0 + ((i % 4) - 1.5) * 0.55 for i in range(80)]))
+    close_plan = apply_position_management(_plan("long"), close_analysis, "long")
+
+    assert close_plan.action == "close"
+    assert close_plan.side == "long"
+    assert "stand_down" in close_plan.note or "confirmed" in close_plan.note


### PR DESCRIPTION
## summary
- replace blended directional voting with a narrow `trend_continuation` lane gated by the regime classifier
- add explicit directional setups (`pullback_long`, `breakout_long`, `failed_bounce_short`, `breakdown_short`) plus deterministic stand-down and invalidation handling
- expose strategy-lane and invalidation attribution in live/replay artifacts and document the lane contract with targeted tests

## validation
- `python3 -m compileall src tests`
- imported affected test modules directly in Python to catch shape/import regressions in this shell

Closes #38

## rollback note
Revert this PR to remove the `trend_continuation` lane, its setup taxonomy/invalidation rules, and the related artifact/doc/test changes if the first directional-lane slice needs to be redesigned.