### PR TITLE
docs: add experimentation roadmap and status generator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,12 @@
 
 If risk changed, describe exactly what and why:
 
+## Roadmap linkage (required for substantive work)
+- Roadmap phase/item:
+- Linked issue(s):
+- This PR: [ ] completes item  [ ] advances item  [ ] partial only
+- If partial only, what remains / who must review manual status:
+
 ## Validation
 - Commands/tests run:
 - Evidence (logs/screenshots):

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ see:
 - `/home/boiler/.openclaw/workspace/LIVE_CHECKLIST.md` (ops companion checklist)
 - `docs/strategy/EXPERIMENTATION_FRAMEWORK_V1.md` (scientific experimentation doctrine)
 - `docs/strategy/EXPERIMENT_GOVERNANCE_POLICY_V1.md` (review, promotion, rejection, and rollback policy)
+- `docs/roadmap/EXPERIMENTATION_ROADMAP_STATUS.md` (generated roadmap / distance-to-readiness status)
 - `docs/README.md` (canonical docs index)
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ Provide one canonical entrypoint for repo documentation so contributors and oper
 | `README.md` | contributor/operator | shared | weekly | yes | repo overview, quickstart, baseline behavior |
 | `docs/architecture.md` | developer/operator | boilerclaw | biweekly | yes | trading/dataflow architecture and strategy logic |
 | `docs/REPO_UPDATE_PROCESS.md` | contributor | shared | weekly | yes | issue-first / PR-gated process contract |
+| `docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json` | contributor/governance | boilermolt | weekly | yes | authored roadmap truth: phases, gates, and issue linkage |
+| `docs/roadmap/EXPERIMENTATION_ROADMAP_STATUS.md` | contributor/governance | boilermolt | weekly | generated | derived current roadmap/gate status from repo state |
 | `boilerclaw/LIVE_RUNBOOK.md` | operator | boilerclaw | weekly | yes | production/live runbook and deploy checks |
 | `docs/operations/RUNBOOK_PAPER_V1.md` | operator | boilermolt | weekly | yes | paper-mode start/verify/recover/rollback runbook |
 | `docs/strategy/STRATEGY_CONTRACT_V1.md` | developer/strategy reviewer | boilermolt | weekly | yes | conservative/aggressive profile contract + risk boundaries |
@@ -42,6 +44,7 @@ Provide one canonical entrypoint for repo documentation so contributors and oper
 
 ### I need to contribute code/docs
 - `docs/REPO_UPDATE_PROCESS.md`
+- `docs/roadmap/EXPERIMENTATION_ROADMAP_STATUS.md`
 - `.github/pull_request_template.md`
 
 ## known gaps (tracked)

--- a/docs/REPO_UPDATE_PROCESS.md
+++ b/docs/REPO_UPDATE_PROCESS.md
@@ -30,6 +30,18 @@ Every PR must include:
 - Risk impact (especially sizing/leverage/kill-switch)
 - Rollback plan
 - Validation evidence (logs/screenshots/commands)
+- Roadmap linkage for substantive work:
+  - roadmap phase/item
+  - linked issue(s)
+  - whether the PR completes, advances, or only partially satisfies the roadmap item
+
+For roadmap-bearing work, contributors should regenerate roadmap status before or during PR prep:
+
+```bash
+./scripts/render_roadmap.py
+```
+
+Ambiguous PRs must not silently advance roadmap state. If a PR is only a partial step, the PR body and linked issue thread must say so explicitly.
 
 ### Required CI checks
 

--- a/docs/roadmap/EXPERIMENTATION_ROADMAP_STATUS.md
+++ b/docs/roadmap/EXPERIMENTATION_ROADMAP_STATUS.md
@@ -1,0 +1,76 @@
+# experimentation roadmap status
+
+## metadata
+- source roadmap: `docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json`
+- status type: generated
+- generation rule: issue-linked roadmap items derive state from GitHub issue metadata where possible
+- ambiguity policy: prefer manual follow-up over silent inference
+
+## gate summary
+- **foundation_complete**: `blocked` — Evidence substrate is trustworthy enough to support disciplined experimentation. (blockers: #46)
+- **experimentation_ready**: `blocked` — The repo can run and review meaningful candidate-vs-baseline experiments with trustable evidence. (blockers: #38, #39, #40, #46)
+- **research_surface_ready**: `blocked` — Humans can navigate evidence without artifact spelunking. (blockers: #47, #48, #49, #50)
+
+## current phase
+- current phase: **trustable foundations** (`phase-0`)
+
+## experimentation-ready definition
+- fixed-window replay is trustworthy
+- decision/regime/setup attribution is inspectable
+- candidate and baseline can be compared on fixed windows
+- governance/evidence rules are explicit enough to review a candidate without vibes
+- at least one real strategy lane can be tested against a baseline under those rules
+
+## trustable foundations
+- gate: `foundation_complete` → `blocked`
+- blockers: #46
+- progress: 4/5 items complete
+
+| item | issue | status | priority |
+|---|---:|---|---|
+| Deterministic replay evidence | #35 | `complete` | `priority:now` |
+| Decision artifact contract | #36 | `complete` | `priority:now` |
+| Explicit market regime classifier | #37 | `complete` | `priority:now` |
+| Experiment governance policy | #42 | `complete` | `priority:now` |
+| Replay input-window integrity validation | #46 | `in_progress` | `priority:now` |
+
+## first experimentation-ready loop
+- gate: `experimentation_ready` → `blocked`
+- blockers: #38, #39, #40, #46
+- progress: 0/3 items complete
+
+| item | issue | status | priority |
+|---|---:|---|---|
+| Directional trend lane | #38 | `in_progress` | `priority:now` |
+| Range / mean reversion lane | #39 | `in_progress` | `priority:next` |
+| Experiment registry | #40 | `planned` | `-` |
+
+## research operating surface
+- gate: `research_surface_ready` → `blocked`
+- blockers: #47, #48, #49, #50
+- progress: 0/4 items complete
+
+| item | issue | status | priority |
+|---|---:|---|---|
+| Experiment run index | #47 | `in_progress` | `priority:later` |
+| Run detail / decision trace | #48 | `in_progress` | `priority:later` |
+| Baseline vs candidate comparison | #49 | `in_progress` | `priority:later` |
+| Promotion/rejection evidence surface | #50 | `planned` | `-` |
+
+## refinement and scaling
+- progress: 0/3 items complete
+
+| item | issue | status | priority |
+|---|---:|---|---|
+| README remake | #44 | `in_progress` | `priority:next` |
+| Experimentation-console umbrella framing | #41 | `planned` | `-` |
+| Roadmap + progress automation | #54 | `planned` | `-` |
+
+## authored-vs-generated split
+- This file is the authored roadmap truth: phases, gate definitions, milestone semantics, and issue linkage.
+- Generated roadmap state must be derived from linked issue/PR metadata plus explicit PR linkage declarations where possible.
+- Automation should prefer under-automation to wrong automation.
+
+## manual override rule
+- If a PR only partially advances a roadmap item, reviewers must record that explicitly in the PR and/or issue thread; the generated roadmap should prefer `planned`/`in_progress` over incorrect completion.
+

--- a/docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json
+++ b/docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json
@@ -1,0 +1,85 @@
+{
+  "version": "v1.0.0",
+  "owner_role": "strategy_governance",
+  "objective": "Make project distance-to-readiness visible and derive roadmap progress from explicit repo state wherever possible.",
+  "status_values": [
+    "planned",
+    "in_progress",
+    "blocked",
+    "complete",
+    "superseded",
+    "manual_review_required"
+  ],
+  "authored_truth": {
+    "notes": [
+      "This file is the authored roadmap truth: phases, gate definitions, milestone semantics, and issue linkage.",
+      "Generated roadmap state must be derived from linked issue/PR metadata plus explicit PR linkage declarations where possible.",
+      "Automation should prefer under-automation to wrong automation."
+    ]
+  },
+  "gates": {
+    "foundation_complete": {
+      "description": "Evidence substrate is trustworthy enough to support disciplined experimentation.",
+      "required_issue_ids": [35, 36, 37, 42, 46]
+    },
+    "experimentation_ready": {
+      "description": "The repo can run and review meaningful candidate-vs-baseline experiments with trustable evidence.",
+      "required_issue_ids": [35, 36, 37, 38, 39, 40, 42, 46],
+      "operational_definition": [
+        "fixed-window replay is trustworthy",
+        "decision/regime/setup attribution is inspectable",
+        "candidate and baseline can be compared on fixed windows",
+        "governance/evidence rules are explicit enough to review a candidate without vibes",
+        "at least one real strategy lane can be tested against a baseline under those rules"
+      ]
+    },
+    "research_surface_ready": {
+      "description": "Humans can navigate evidence without artifact spelunking.",
+      "required_issue_ids": [47, 48, 49, 50]
+    }
+  },
+  "phases": [
+    {
+      "id": "phase-0",
+      "name": "trustable foundations",
+      "gate": "foundation_complete",
+      "items": [
+        {"id": "replay-foundation", "title": "Deterministic replay evidence", "issue": 35, "category": "foundation"},
+        {"id": "decision-contract", "title": "Decision artifact contract", "issue": 36, "category": "foundation"},
+        {"id": "regime-classifier", "title": "Explicit market regime classifier", "issue": 37, "category": "foundation"},
+        {"id": "governance-policy", "title": "Experiment governance policy", "issue": 42, "category": "governance"},
+        {"id": "replay-integrity", "title": "Replay input-window integrity validation", "issue": 46, "category": "foundation"}
+      ]
+    },
+    {
+      "id": "phase-1",
+      "name": "first experimentation-ready loop",
+      "gate": "experimentation_ready",
+      "items": [
+        {"id": "trend-lane", "title": "Directional trend lane", "issue": 38, "category": "strategy-lane"},
+        {"id": "range-lane", "title": "Range / mean reversion lane", "issue": 39, "category": "strategy-lane"},
+        {"id": "experiment-registry", "title": "Experiment registry", "issue": 40, "category": "registry"}
+      ]
+    },
+    {
+      "id": "phase-2",
+      "name": "research operating surface",
+      "gate": "research_surface_ready",
+      "items": [
+        {"id": "run-index", "title": "Experiment run index", "issue": 47, "category": "ux"},
+        {"id": "run-detail", "title": "Run detail / decision trace", "issue": 48, "category": "ux"},
+        {"id": "comparison-workflow", "title": "Baseline vs candidate comparison", "issue": 49, "category": "ux"},
+        {"id": "promotion-surface", "title": "Promotion/rejection evidence surface", "issue": 50, "category": "ux"}
+      ]
+    },
+    {
+      "id": "phase-3",
+      "name": "refinement and scaling",
+      "items": [
+        {"id": "experimentation-console-umbrella", "title": "Experimentation-console umbrella framing", "issue": 41, "category": "ux-umbrella"},
+        {"id": "readme-refresh", "title": "README remake", "issue": 44, "category": "docs"},
+        {"id": "roadmap-automation", "title": "Roadmap + progress automation", "issue": 54, "category": "meta"}
+      ]
+    }
+  ]
+}

--- a/scripts/render_roadmap.py
+++ b/scripts/render_roadmap.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = "BoilerHAUS/avantis-paper-bot"
+ROOT = Path(__file__).resolve().parent.parent
+ROADMAP_JSON = ROOT / "docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json"
+OUT_MD = ROOT / "docs/roadmap/EXPERIMENTATION_ROADMAP_STATUS.md"
+
+STATUS_ORDER = {
+    "complete": 0,
+    "in_progress": 1,
+    "blocked": 2,
+    "planned": 3,
+    "superseded": 4,
+    "manual_review_required": 5,
+}
+
+
+def gh_json(args: list[str]) -> Any:
+    cmd = ["gh", *args]
+    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
+def fetch_issues(issue_numbers: list[int]) -> dict[int, dict[str, Any]]:
+    out: dict[int, dict[str, Any]] = {}
+    for n in issue_numbers:
+        issue = gh_json(["issue", "view", str(n), "--repo", REPO, "--json", "number,title,state,labels,url,closedAt"])
+        out[n] = issue
+    return out
+
+
+def item_status(issue: dict[str, Any]) -> str:
+    if issue["state"].upper() == "CLOSED":
+        return "complete"
+    labels = {label["name"] for label in issue.get("labels", [])}
+    if "blocked" in labels:
+        return "blocked"
+    if "superseded" in labels:
+        return "superseded"
+    if any(label.startswith("priority:") for label in labels):
+        return "in_progress"
+    return "planned"
+
+
+def gate_status(required_issue_ids: list[int], issue_map: dict[int, dict[str, Any]]) -> tuple[str, list[int]]:
+    incomplete = [n for n in required_issue_ids if item_status(issue_map[n]) != "complete"]
+    if not incomplete:
+        return "complete", []
+    return "blocked", incomplete
+
+
+def render() -> str:
+    roadmap = json.loads(ROADMAP_JSON.read_text(encoding="utf-8"))
+    all_issue_ids = [item["issue"] for phase in roadmap["phases"] for item in phase["items"]]
+    gate_issue_ids = [n for gate in roadmap["gates"].values() for n in gate["required_issue_ids"]]
+    issue_ids = sorted(set(all_issue_ids + gate_issue_ids))
+    issues = fetch_issues(issue_ids)
+
+    lines: list[str] = []
+    lines.append("# experimentation roadmap status")
+    lines.append("")
+    lines.append("## metadata")
+    lines.append(f"- source roadmap: `docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json`")
+    lines.append("- status type: generated")
+    lines.append("- generation rule: issue-linked roadmap items derive state from GitHub issue metadata where possible")
+    lines.append("- ambiguity policy: prefer manual follow-up over silent inference")
+    lines.append("")
+
+    # gate summary
+    lines.append("## gate summary")
+    for gate_id, gate in roadmap["gates"].items():
+        status, blockers = gate_status(gate["required_issue_ids"], issues)
+        blocker_text = "none" if not blockers else ", ".join(f"#{n}" for n in blockers)
+        lines.append(f"- **{gate_id}**: `{status}` — {gate['description']} (blockers: {blocker_text})")
+    lines.append("")
+
+    # current phase
+    current_phase = None
+    for phase in roadmap["phases"]:
+        if any(item_status(issues[item["issue"]]) != "complete" for item in phase["items"]):
+            current_phase = phase
+            break
+    if current_phase is None:
+        current_phase = roadmap["phases"][-1]
+    lines.append("## current phase")
+    lines.append(f"- current phase: **{current_phase['name']}** (`{current_phase['id']}`)")
+    lines.append("")
+
+    lines.append("## experimentation-ready definition")
+    for bullet in roadmap["gates"]["experimentation_ready"].get("operational_definition", []):
+        lines.append(f"- {bullet}")
+    lines.append("")
+
+    for phase in roadmap["phases"]:
+        lines.append(f"## {phase['name']}")
+        if "gate" in phase:
+            gate = roadmap["gates"][phase["gate"]]
+            gate_state, blockers = gate_status(gate["required_issue_ids"], issues)
+            lines.append(f"- gate: `{phase['gate']}` → `{gate_state}`")
+            if blockers:
+                lines.append(f"- blockers: {', '.join(f'#{n}' for n in blockers)}")
+        complete_count = sum(1 for item in phase["items"] if item_status(issues[item["issue"]]) == "complete")
+        total_count = len(phase["items"])
+        lines.append(f"- progress: {complete_count}/{total_count} items complete")
+        lines.append("")
+        lines.append("| item | issue | status | priority |")
+        lines.append("|---|---:|---|---|")
+        phase_items = sorted(
+            phase["items"],
+            key=lambda item: (STATUS_ORDER.get(item_status(issues[item["issue"]]), 99), item["issue"]),
+        )
+        for item in phase_items:
+            issue = issues[item["issue"]]
+            status = item_status(issue)
+            labels = {label["name"] for label in issue.get("labels", [])}
+            priority = next((l for l in sorted(labels) if l.startswith("priority:")), "-")
+            lines.append(f"| {item['title']} | #{item['issue']} | `{status}` | `{priority}` |")
+        lines.append("")
+
+    lines.append("## authored-vs-generated split")
+    for note in roadmap["authored_truth"]["notes"]:
+        lines.append(f"- {note}")
+    lines.append("")
+    lines.append("## manual override rule")
+    lines.append("- If a PR only partially advances a roadmap item, reviewers must record that explicitly in the PR and/or issue thread; the generated roadmap should prefer `planned`/`in_progress` over incorrect completion.")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    try:
+        content = render()
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.stderr)
+        return exc.returncode
+    OUT_MD.parent.mkdir(parents=True, exist_ok=True)
+    OUT_MD.write_text(content, encoding="utf-8")
+    print(f"wrote {OUT_MD}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_roadmap.py
+++ b/scripts/render_roadmap.py
@@ -67,7 +67,7 @@ def render() -> str:
     lines.append("# experimentation roadmap status")
     lines.append("")
     lines.append("## metadata")
-    lines.append(f"- source roadmap: `docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json`")
+    lines.append("- source roadmap: `docs/roadmap/EXPERIMENTATION_ROADMAP_V1.json`")
     lines.append("- status type: generated")
     lines.append("- generation rule: issue-linked roadmap items derive state from GitHub issue metadata where possible")
     lines.append("- ambiguity policy: prefer manual follow-up over silent inference")
@@ -120,7 +120,7 @@ def render() -> str:
             issue = issues[item["issue"]]
             status = item_status(issue)
             labels = {label["name"] for label in issue.get("labels", [])}
-            priority = next((l for l in sorted(labels) if l.startswith("priority:")), "-")
+            priority = next((label for label in sorted(labels) if label.startswith("priority:")), "-")
             lines.append(f"| {item['title']} | #{item['issue']} | `{status}` | `{priority}` |")
         lines.append("")
 


### PR DESCRIPTION
## Summary
- add an authored roadmap source file with phases, gate definitions, issue linkage, and an explicit experimentation-ready definition
- add a lightweight roadmap status generator that derives current gate/item state from linked GitHub issues
- update the PR template and repo update process so substantive PRs must declare roadmap linkage and whether they complete/advance/partial a roadmap item

## Scope
- [ ] code
- [ ] config
- [ ] infra/deploy
- [x] docs

## Docs impact checklist (required when docs touched)
- [x] changed sections summary included
- [x] downstream docs touched listed (or `none`)
- [x] canonical docs index updated (or reason why not)
- [x] ran: `bash ./scripts/docs/check_docs.sh`

Downstream docs touched:
- `docs/README.md`
- `docs/REPO_UPDATE_PROCESS.md`
- `README.md`

## Roadmap linkage (required for substantive work)
- Roadmap phase/item: phase-3 / roadmap-automation
- Linked issue(s): #54
- This PR: [x] completes item  [ ] advances item  [ ] partial only
- If partial only, what remains / who must review manual status:

## Risk impact
- [x] no trading risk changes
- [ ] includes trading risk changes (label `risk-change` required)

If risk changed, describe exactly what and why:
- none

## Validation
- Commands/tests run:
  - `bash ./scripts/docs/check_docs.sh`
  - `./scripts/render_roadmap.py`
- Evidence (logs/screenshots):
  - docs quality gate passed
  - roadmap status file regenerated successfully

## Rollback plan
- revert this PR to remove the roadmap source/status files, generator script, and PR/process linkage updates if the first roadmap slice needs a different structure

## Post-deploy checks
- [ ] candles are fresh
- [ ] cycle/journal are fresh
- [ ] dashboard reflects current state

Closes #54
